### PR TITLE
Adds the API URL to environment variable

### DIFF
--- a/app/controllers/signup.js
+++ b/app/controllers/signup.js
@@ -1,8 +1,9 @@
 import Controller from '@ember/controller';
 import { tracked } from '@glimmer/tracking';
 import { action, set } from '@ember/object';
+import ENV from 'website-my/config/environment';
 
-const BASE_URL = 'https://staging-api.realdevsquad.com';
+const BASE_URL = ENV.BASE_API_URL;
 
 export default class SignupController extends Controller {
   @tracked isSubmitDisabled = true;

--- a/config/environment.js
+++ b/config/environment.js
@@ -47,5 +47,6 @@ module.exports = function (environment) {
     // here you can enable a production-specific feature
   }
 
+  ENV.BASE_API_URL = 'https://staging-api.realdevsquad.com';
   return ENV;
 };

--- a/config/environment.js
+++ b/config/environment.js
@@ -23,6 +23,8 @@ module.exports = function (environment) {
     },
   };
 
+  ENV.BASE_API_URL = 'https://api.realdevsquad.com';
+
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
@@ -47,6 +49,5 @@ module.exports = function (environment) {
     // here you can enable a production-specific feature
   }
 
-  ENV.BASE_API_URL = 'https://staging-api.realdevsquad.com';
   return ENV;
 };


### PR DESCRIPTION
Since we'll be shifting our backend to production, the base API url will also be changed. Better if it is in environment variables, just in case we change the endpoint, we won't have to make changes at 100 places where we're making the API calls.