### PR TITLE
lint script fix for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "ember serve --port=80",
     "build": "ember build --environment production && cp _redirects dist/_redirects",
-    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel 'lint:!(fix)'",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:!(fix)",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",
@@ -66,5 +66,8 @@
   },
   "ember": {
     "edition": "octane"
+  },
+  "dependencies": {
+    "glob": "^7.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,8 +66,5 @@
   },
   "ember": {
     "edition": "octane"
-  },
-  "dependencies": {
-    "glob": "^7.1.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "ember serve --port=80",
     "build": "ember build --environment production && cp _redirects dist/_redirects",
-    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:!(fix)",
+    "lint": "npm-run-all --aggregate-output --continue-on-error --parallel \"lint:!(fix)\"",
     "lint:fix": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*:fix",
     "lint:hbs": "ember-template-lint .",
     "lint:hbs:fix": "ember-template-lint . --fix",


### PR DESCRIPTION
"lint": "npm-run-all --aggregate-output --continue-on-error --parallel 'lint:!(fix)'", --> "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:!(fix)",