### PR TITLE
center the notifications vertically and horizontally

### DIFF
--- a/app/styles/notification.css
+++ b/app/styles/notification.css
@@ -1,8 +1,12 @@
+.notifications-holder {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+}
+
 .new-message-box {
-    margin-left: 300px;
-    margin-top: 30px;
-    padding-left: 20px;
-    max-width: 800px;
+    width: 800px;
 }
 
 .info-tab {

--- a/app/templates/notifications.hbs
+++ b/app/templates/notifications.hbs
@@ -1,3 +1,5 @@
-{{#each @model as |post|}}
-  <NotificationCard @title={{post.title}} @description={{post.description}} />
-{{/each}}
+<div class="notifications-holder">
+  {{#each @model as |post|}}
+    <NotificationCard @title={{post.title}} @description={{post.description}} />
+  {{/each}}
+</div>


### PR DESCRIPTION
Fixes #202 
I have also added slight margin between the orange element and the text

Before:
![image](https://user-images.githubusercontent.com/56217868/149969192-4a174a53-de0c-45df-a4b4-acbc23bf63ed.png)


After:
![image](https://user-images.githubusercontent.com/56217868/149969239-d853c012-0205-489c-8763-6656dc7442c3.png)
