### PR TITLE
fix-percent input getting hidden after updating percent value

### DIFF
--- a/app/controllers/tasks.js
+++ b/app/controllers/tasks.js
@@ -36,7 +36,7 @@ export default class TasksController extends Controller {
   }
 
   constructReqBody(object) {
-    const requestBody = { status: object.status };
+    const requestBody = { ...object };
     const taskCompletionPercentage = object.percentCompleted;
     if (taskCompletionPercentage) {
       requestBody.percentCompleted = parseInt(taskCompletionPercentage);


### PR DESCRIPTION
fixes #272

### PROBLEM
When we are updating the `percentCompleted` value in the task card, after updating the task `percentCompleted` input field is getting hidden.

https://user-images.githubusercontent.com/79859472/193445523-0d2c4579-58af-471d-9572-3e8beb1d8ae1.mp4


### DESCRIPTION
When we update the `percentCompleted` value, then it will fire an API call to update the `percentCompleted` related to that task. We will send tasks `percentCompleted` and `status` to the backend.

We have a `taksFields` object for storing `percentCompleted` and `status`, initialised with an `empty` object.

When we update the `percentCompleted` value it will store the `percentCompleted` value inside `task fields
` object and fire an API call.

Before sending `taskFields` data we will pass that data to the `construct body` method. 

```js
constructReqBody(object) {
    const requestBody = { status: object.status };
    const taskCompletionPercentage = object.percentCompleted;
    if (taskCompletionPercentage) {
      requestBody.percentCompleted = parseInt(taskCompletionPercentage);
    }
    return requestBody;
  }
```

Inside the `construct body` method we are getting the status property from the taskFields object, but currently, that is undefined.

So, after the API call completes it will set the `status` of that task to undefined. 

`percentCompleted` will be in the view only if `status` is IN_PROGRESS. So, the status changed to undefined will hide the `percentCompleted` input field.

### SOLUTION

```js
const requestBody = { ...object };
```

Instead of explicitly setting the status inside the construct body method, I am adding whatever is currently inside the taskFields object. This will prevent the status from being undefined.

https://user-images.githubusercontent.com/79859472/193448162-852db275-7a5b-4ce2-8264-ad78308d6a37.mp4

