### PR TITLE
handles the case when user status not found in collection

### DIFF
--- a/app/components/user-status.hbs
+++ b/app/components/user-status.hbs
@@ -9,12 +9,11 @@
 <div class="buttons">
   {{#each this.currentUserStatus as |currentStatus|}}
     {{#if (eq @status currentStatus.status)}}
-        <button class={{currentStatus.firstStatusClass}} type="button" data-test-button disabled={{@isStatusUpdating}} {{on "click" (fn @onChangeStatus currentStatus.firstAvailableStatus )}}>
-          <span data-test-button-text>{{currentStatus.firstStatusMessage}}</span>
+      {{#each currentStatus.otherAvailableStatus as |otherPossibleStatus|}}
+        <button class={{otherPossibleStatus.class}} type="button" disabled={{@isStatusUpdating}} {{on "click" (fn @onChangeStatus otherPossibleStatus.status )}}>
+          <span>{{otherPossibleStatus.message}}</span>
         </button>
-      <button class={{currentStatus.secondStatusClass}} type="button" disabled={{@isStatusUpdating}} {{on "click" (fn @onChangeStatus currentStatus.secondAvailableStatus )}}>
-        <span>{{currentStatus.secondStatusMessage}}</span>
-      </button>
+      {{/each}}
     {{/if}}
   {{/each}}
 </div>

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -1,36 +1,56 @@
 import Component from '@glimmer/component';
 import { USER_STATES } from '../constants/user-status';
 export default class UserStatusComponent extends Component {
+  ALL_FEASIBLE_STATUS = {
+    [USER_STATES.ACTIVE]: {
+      status: USER_STATES.ACTIVE,
+      message: 'Change your status status to Active',
+      class: 'buttons__active',
+    },
+    [USER_STATES.IDLE]: {
+      status: USER_STATES.IDLE,
+      message: 'Change your status status to Idle',
+      class: 'buttons__idle',
+    },
+    [USER_STATES.OOO]: {
+      status: USER_STATES.OOO,
+      message: 'Change your status status to OOO',
+      class: 'buttons__ooo',
+    },
+  };
   currentUserStatus = [
     {
       status: USER_STATES.ACTIVE,
       message: 'You are Active',
-      firstAvailableStatus: USER_STATES.IDLE,
-      firstStatusMessage: 'Change your status to Idle',
-      firstStatusClass: 'buttons__idle',
-      secondAvailableStatus: USER_STATES.OOO,
-      secondStatusMessage: 'Change your status to OOO',
-      secondStatusClass: 'buttons__ooo',
+      otherAvailableStatus: [
+        this.ALL_FEASIBLE_STATUS.IDLE,
+        this.ALL_FEASIBLE_STATUS.OOO,
+      ],
     },
     {
       status: USER_STATES.IDLE,
       message: 'You are Idle',
-      firstAvailableStatus: USER_STATES.ACTIVE,
-      firstStatusMessage: 'Change your status status to Active',
-      firstStatusClass: 'buttons__active',
-      secondAvailableStatus: USER_STATES.OOO,
-      secondStatusMessage: 'Change your status status to OOO',
-      secondStatusClass: 'buttons__ooo',
+      otherAvailableStatus: [
+        this.ALL_FEASIBLE_STATUS.ACTIVE,
+        this.ALL_FEASIBLE_STATUS.OOO,
+      ],
     },
     {
       status: USER_STATES.OOO,
       message: 'You are OOO',
-      firstAvailableStatus: USER_STATES.IDLE,
-      firstStatusMessage: 'Change your status status to Idle',
-      firstStatusClass: 'buttons__idle',
-      secondAvailableStatus: USER_STATES.ACTIVE,
-      secondStatusMessage: 'Change your status status to Active',
-      secondStatusClass: 'buttons__active',
+      otherAvailableStatus: [
+        this.ALL_FEASIBLE_STATUS.ACTIVE,
+        this.ALL_FEASIBLE_STATUS.IDLE,
+      ],
+    },
+    {
+      status: USER_STATES.DNE,
+      message: `Your Staus doesn't exist`,
+      otherAvailableStatus: [
+        this.ALL_FEASIBLE_STATUS.ACTIVE,
+        this.ALL_FEASIBLE_STATUS.IDLE,
+        this.ALL_FEASIBLE_STATUS.OOO,
+      ],
     },
   ];
 }

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -4,17 +4,17 @@ export default class UserStatusComponent extends Component {
   ALL_FEASIBLE_STATUS = {
     [USER_STATES.ACTIVE]: {
       status: USER_STATES.ACTIVE,
-      message: 'Change your status status to Active',
+      message: 'Change your status to Active',
       class: 'buttons__active',
     },
     [USER_STATES.IDLE]: {
       status: USER_STATES.IDLE,
-      message: 'Change your status status to Idle',
+      message: 'Change your status to Idle',
       class: 'buttons__idle',
     },
     [USER_STATES.OOO]: {
       status: USER_STATES.OOO,
-      message: 'Change your status status to OOO',
+      message: 'Change your status to OOO',
       class: 'buttons__ooo',
     },
   };
@@ -45,7 +45,7 @@ export default class UserStatusComponent extends Component {
     },
     {
       status: USER_STATES.DNE,
-      message: `Your Staus doesn't exist`,
+      message: `Your Status doesn't exist`,
       otherAvailableStatus: [
         this.ALL_FEASIBLE_STATUS.ACTIVE,
         this.ALL_FEASIBLE_STATUS.IDLE,

--- a/app/constants/user-status.js
+++ b/app/constants/user-status.js
@@ -4,6 +4,11 @@ export const WARNING_MESSAGE_FOR_OOO =
   'The Reason Field is mandatory. Please mention the reason for going OOO.';
 export const WARNING_MESSAGE_FOR_IDLE =
   'The Missing Skills Field is mandatory. Please mention the skills you are lagging in.';
-export const USER_STATES = { IDLE: 'IDLE', ACTIVE: 'ACTIVE', OOO: 'OOO' };
+export const USER_STATES = {
+  IDLE: 'IDLE',
+  ACTIVE: 'ACTIVE',
+  OOO: 'OOO',
+  DNE: 'DNE',
+};
 export const WARNING_FROM_DATE_EXCEEDS_UNTIL_DATE =
   'Until date cant lie before the From date. Please recheck the dates again.';

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -8,14 +8,13 @@ const API_BASE_URL = ENV.BASE_API_URL;
 export default class IndexRoute extends Route {
   @service toast;
   model = async () => {
-    const defaultStatus = USER_STATES.ACTIVE;
     try {
       const response = await fetch(`${API_BASE_URL}/users/status/self`, {
         credentials: 'include',
       });
       const userData = await response.json();
       if (response.status === 200) {
-        return userData?.data?.currentStatus?.state ?? defaultStatus;
+        return userData?.data?.currentStatus?.state ?? USER_STATES.DNE;
       } else if (response.status === 401) {
         this.toast.error(
           'You are not logged in. Please login to continue.',
@@ -32,7 +31,7 @@ export default class IndexRoute extends Route {
         }, 2000);
       } else if (response.status === 404) {
         this.toast.error(
-          `Your Status data doesnt exist yet.Please choose your status from the options below.`,
+          `Your Status data doesn't exist yet. Please choose your status from the options below.`,
           '',
           toastNotificationTimeoutOptions
         );

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -14,7 +14,7 @@ export default class IndexRoute extends Route {
         credentials: 'include',
       });
       const userData = await response.json();
-      if (response.status === 200 && !userData.incompleteUserDetails) {
+      if (response.status === 200) {
         return userData?.data?.currentStatus?.state ?? defaultStatus;
       } else if (response.status === 401) {
         this.toast.error(
@@ -30,6 +30,13 @@ export default class IndexRoute extends Route {
           }
           window.open(authUrl, '_self');
         }, 2000);
+      } else if (response.status === 404) {
+        this.toast.error(
+          `Your Status data doesnt exist yet.Please choose your status from the options below.`,
+          '',
+          toastNotificationTimeoutOptions
+        );
+        return USER_STATES.DNE;
       }
     } catch (error) {
       console.error(error.message);


### PR DESCRIPTION
Currently, if the User Status is not found then that page is empty. Handled the case for API response 404. Added an option to select from the list of available responses.

![image](https://user-images.githubusercontent.com/97341921/206837750-bf9de86c-876f-4120-9f77-ccd6c64737d5.png)



