### PR TITLE
Feat/user status modal

### DIFF
--- a/app/components/user-status-modal.hbs
+++ b/app/components/user-status-modal.hbs
@@ -2,8 +2,7 @@
 <div class="overlay">
   <div class="modal" data-test-modal>
     <div class="modal__inputs">
-      {{#if (eq @newStatus 'OOO')}}
-      
+      {{#if (eq @newStatus this.USER_STATES.OOO)}}      
       <label class="modal__inputs--description" data-test-label-from>From</label>
       <Input name='fromDate' type='date' min={{this.disableDatesPrior}} value={{this.fromDate}} {{on "change"
         this.updateValue}} data-test-date-picker-from />
@@ -11,12 +10,9 @@
       <Input name='untilDate' type='date' min={{if this.fromDate this.fromDate this.disableDatesPrior}}
         value={{this.untilDate}} {{on "change" this.updateValue}} data-test-date-picker-until />
       <label class="modal__inputs--description" data-test-label-reason>Reason</label>
-
-      {{else if (eq @newStatus 'IDLE')}}
-
+      {{else if (eq @newStatus this.USER_STATES.IDLE)}}
       <label class="modal__inputs--description" data-test-label-missing-skills>What skills are you willing to
         learn</label>
-
       {{/if}}
 
       <textarea name='reason' class="modal__text-area" value={{this.reason}} {{on "input" this.handleInput}}

--- a/app/components/user-status-modal.hbs
+++ b/app/components/user-status-modal.hbs
@@ -2,31 +2,30 @@
 <div class="overlay">
   <div class="modal" data-test-modal>
     <div class="modal__inputs">
-      <label class="modal__inputs--description" data-test-label-from>From</label>
-      <Input name='fromDate' type='date' value={{this.fromDate}} {{on "change" this.updateValue}}
-        data-test-date-picker-from />
+      {{#if (eq @newStatus 'OOO')}}
       
-      {{#if (eq @newStatus 'OOO')}}
+      <label class="modal__inputs--description" data-test-label-from>From</label>
+      <Input name='fromDate' type='date' min={{this.disableDatesPrior}} value={{this.fromDate}} {{on "change"
+        this.updateValue}} data-test-date-picker-from />
       <label class="modal__inputs--description" data-test-label-until>Until</label>
-      <Input name='untilDate' type='date' value={{this.untilDate}} {{on "change" this.updateValue}}
-        data-test-date-picker-until />
-      {{/if}}
-
-      {{#if (not-eq @newStatus 'ACTIVE')}}
-      {{#if (eq @newStatus 'OOO')}}
+      <Input name='untilDate' type='date' min={{if this.fromDate this.fromDate this.disableDatesPrior}}
+        value={{this.untilDate}} {{on "change" this.updateValue}} data-test-date-picker-until />
       <label class="modal__inputs--description" data-test-label-reason>Reason</label>
+
+      {{else if (eq @newStatus 'IDLE')}}
+
+      <label class="modal__inputs--description" data-test-label-missing-skills>What skills are you willing to
+        learn</label>
+
       {{/if}}
 
-      {{#if (eq @newStatus 'IDLE')}}
-      <label class="modal__inputs--description" data-test-label-missing-skills>What skills are you willing to learn</label>
-      {{/if}}
-
-      <textarea name='reason' class="modal__text-area" value={{this.reason}} {{on "change" this.updateValue}}
+      <textarea name='reason' class="modal__text-area" value={{this.reason}} {{on "input" this.handleInput}}
         data-test-textarea-reason></textarea>
-      {{/if}}
 
     </div>
-    <button type="button" class="modal__submit" {{on "click" this.getCurrentStatusObj}} data-test-submit-button>
+    <button disabled={{this.disableSubmitButton}} type="button" class={{if
+      this.disableSubmitButton "modal__submit--disabled" "modal__submit" }} {{on "click" this.getCurrentStatusObj}}
+      data-test-submit-button>
       Submit
     </button>
     <button type="button" class="modal__close" {{on "click" this.onCancelModal}} data-test-cancel-button>

--- a/app/components/user-status-modal.js
+++ b/app/components/user-status-modal.js
@@ -11,6 +11,9 @@ import {
   USER_STATES,
   WARNING_FROM_DATE_EXCEEDS_UNTIL_DATE,
   THREE_DAYS_TIME_DIFFERENCE_MS,
+  FROM_DATE,
+  UNTIL_DATE,
+  REASON,
 } from '../constants/user-status';
 
 export default class FormStatusModal extends Component {
@@ -26,14 +29,14 @@ export default class FormStatusModal extends Component {
   @action
   updateValue(event) {
     const { name, value } = event.target;
-    if (name === 'fromDate') {
+    if (name === FROM_DATE) {
       this.fromDate = value;
-    } else if (name === 'untilDate') {
+    } else if (name === UNTIL_DATE) {
       this.untilDate = value;
-    } else if (name === 'reason') {
+    } else if (name === REASON) {
       this.reason = value;
     }
-    this.checkSubmitBttnState();
+    this.checkSubmitBtnState();
   }
 
   @action
@@ -105,11 +108,11 @@ export default class FormStatusModal extends Component {
   handleInput(event) {
     const { value } = event.target;
     this.reason = value;
-    this.checkSubmitBttnState();
+    this.checkSubmitBtnState();
   }
 
   @action
-  checkSubmitBttnState() {
+  checkSubmitBtnState() {
     this.disableSubmitButton = true;
     if (this.args.newStatus === USER_STATES.OOO) {
       if (this.checkIfFromToDatesAreClose()) {

--- a/app/components/user-status-modal.js
+++ b/app/components/user-status-modal.js
@@ -10,6 +10,7 @@ import {
   WARNING_MESSAGE_FOR_UNTIL_FIELD,
   USER_STATES,
   WARNING_FROM_DATE_EXCEEDS_UNTIL_DATE,
+  THREE_DAYS_TIME_DIFFERENCE_MS,
 } from '../constants/user-status';
 
 export default class FormStatusModal extends Component {
@@ -20,6 +21,7 @@ export default class FormStatusModal extends Component {
   @tracked reason = '';
   @tracked disableSubmitButton = true;
   @tracked disableDatesPrior = new Date().toJSON().slice(0, 10);
+  USER_STATES = USER_STATES;
 
   @action
   updateValue(event) {
@@ -132,8 +134,7 @@ export default class FormStatusModal extends Component {
       let from = new Date(this.fromDate.replaceAll('-', ',')).getTime();
       let until = new Date(this.untilDate.replaceAll('-', ',')).getTime();
       const timeGap = until - from;
-      // 172800000 is the no of milli seconds in 3 days. as reason field is not mandatory if its less than 3 days
-      return timeGap <= 172800000;
+      return timeGap <= THREE_DAYS_TIME_DIFFERENCE_MS;
     }
     return false;
   }

--- a/app/components/user-status-modal.js
+++ b/app/components/user-status-modal.js
@@ -96,6 +96,7 @@ export default class FormStatusModal extends Component {
     };
     await this.args.updateStatus({ currentStatus: newStateObj });
     this.resetInputFields();
+    this.disableSubmitButton = true;
   }
 
   @action

--- a/app/components/user-status-modal.js
+++ b/app/components/user-status-modal.js
@@ -15,7 +15,6 @@ import {
 export default class FormStatusModal extends Component {
   @service toast;
   @tracked currentStatus;
-  @tracked newStatus;
   @tracked fromDate = '';
   @tracked untilDate = '';
   @tracked reason = '';

--- a/app/components/user-status.hbs
+++ b/app/components/user-status.hbs
@@ -1,3 +1,8 @@
+{{#if @isStatusUpdating}}
+  <div class="loading">
+    <Spinner />
+  </div>
+{{else}}
 <div class="heading">
   {{#each this.currentUserStatus as |currentStatus|}}
     {{#if (eq @status currentStatus.status)}}
@@ -17,3 +22,4 @@
     {{/if}}
   {{/each}}
 </div>
+{{/if}}

--- a/app/components/user-status.hbs
+++ b/app/components/user-status.hbs
@@ -10,7 +10,7 @@
   {{#each this.currentUserStatus as |currentStatus|}}
     {{#if (eq @status currentStatus.status)}}
       {{#each currentStatus.otherAvailableStatus as |otherPossibleStatus|}}
-        <button class={{otherPossibleStatus.class}} type="button" disabled={{@isStatusUpdating}} {{on "click" (fn @onChangeStatus otherPossibleStatus.status )}}>
+        <button class={{otherPossibleStatus.class}} type="button" disabled={{@isStatusUpdating}} {{on "click" (fn this.changeStatus otherPossibleStatus.status )}}>
           <span>{{otherPossibleStatus.message}}</span>
         </button>
       {{/each}}

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -58,14 +58,14 @@ export default class UserStatusComponent extends Component {
   @action async changeStatus(status) {
     if (status === USER_STATES.ACTIVE) {
       const updatedAt = Date.now();
-      const activeStateObj = {
+      const activeStateData = {
         updatedAt,
         from: updatedAt,
         until: undefined,
         message: undefined,
         state: USER_STATES.ACTIVE,
       };
-      await this.args.updateStatus({ currentStatus: activeStateObj });
+      await this.args.updateStatus({ currentStatus: activeStateData });
     } else {
       this.args.changeStatus(status);
     }

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -1,4 +1,5 @@
 import Component from '@glimmer/component';
+import { action } from '@ember/object';
 import { USER_STATES } from '../constants/user-status';
 export default class UserStatusComponent extends Component {
   ALL_FEASIBLE_STATUS = {
@@ -53,4 +54,20 @@ export default class UserStatusComponent extends Component {
       ],
     },
   ];
+
+  @action async changeStatus(status) {
+    if (status === USER_STATES.ACTIVE) {
+      const updatedAt = Date.now();
+      const activeStateObj = {
+        updatedAt,
+        from: updatedAt,
+        until: undefined,
+        message: undefined,
+        state: USER_STATES.ACTIVE,
+      };
+      await this.args.updateStatus({ currentStatus: activeStateObj });
+    } else {
+      this.args.changeStatus(status);
+    }
+  }
 }

--- a/app/constants/user-status.js
+++ b/app/constants/user-status.js
@@ -13,3 +13,6 @@ export const USER_STATES = {
 export const WARNING_FROM_DATE_EXCEEDS_UNTIL_DATE =
   'Until date cant lie before the From date. Please recheck the dates again.';
 export const THREE_DAYS_TIME_DIFFERENCE_MS = 172800000;
+export const FROM_DATE = 'fromDate';
+export const UNTIL_DATE = 'untilDate';
+export const REASON = 'reason';

--- a/app/constants/user-status.js
+++ b/app/constants/user-status.js
@@ -12,3 +12,4 @@ export const USER_STATES = {
 };
 export const WARNING_FROM_DATE_EXCEEDS_UNTIL_DATE =
   'Until date cant lie before the From date. Please recheck the dates again.';
+export const THREE_DAYS_TIME_DIFFERENCE_MS = 172800000;

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -33,8 +33,15 @@ export default class IndexController extends Controller {
         },
         credentials: 'include',
       });
-      if (response.ok) {
+      const { status, statusText } = response;
+      if (status === 200) {
         this.status = newStatus.currentStatus.state;
+      } else {
+        this.toast.error(
+          `${statusText}. Status Update failed`,
+          '',
+          toastNotificationTimeoutOptions
+        );
       }
     } catch (error) {
       console.error('Error : ', error);

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -4,6 +4,7 @@ import { action } from '@ember/object';
 import ENV from 'website-my/config/environment';
 import { inject as service } from '@ember/service';
 import { toastNotificationTimeoutOptions } from '../constants/toast-notification';
+import { USER_STATES } from '../constants/user-status';
 
 const BASE_URL = ENV.BASE_API_URL;
 
@@ -41,11 +42,13 @@ export default class IndexController extends Controller {
       );
     } finally {
       this.isStatusUpdating = false;
+      if (newStatus.currentStatus.state !== USER_STATES.ACTIVE) {
+        this.toggleUserStateModal();
+      }
     }
-    this.toggleUserStateModal();
   }
 
-  @action async changeStatus(status) {
+  @action changeStatus(status) {
     this.newStatus = status;
     this.toggleUserStateModal();
   }

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -21,6 +21,9 @@ export default class IndexController extends Controller {
 
   @action async updateStatus(newStatus) {
     this.isStatusUpdating = true;
+    if (newStatus.currentStatus.state !== USER_STATES.ACTIVE) {
+      this.toggleUserStateModal();
+    }
     try {
       const response = await fetch(`${BASE_URL}/users/status/self`, {
         method: 'PATCH',
@@ -42,9 +45,6 @@ export default class IndexController extends Controller {
       );
     } finally {
       this.isStatusUpdating = false;
-      if (newStatus.currentStatus.state !== USER_STATES.ACTIVE) {
-        this.toggleUserStateModal();
-      }
     }
   }
 

--- a/app/styles/user-status-modal.css
+++ b/app/styles/user-status-modal.css
@@ -49,6 +49,17 @@
   cursor: pointer;
 }
 
+.modal__submit--disabled {
+  display: block;
+  width: 20%;
+  margin: 0.4rem;
+  padding: 0.5rem;
+  background-color: var(--fetch--button--bg--disabled);
+  border: none;
+  color: var(--button-proceed--text);
+  cursor: pointer;
+}
+
 .modal__close {
   background-color: var(--close--bg);
   border: none;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -4,8 +4,9 @@
 
 <UserStatus 
   @status={{this.status}} 
-  @onChangeStatus={{this.changeStatus}} 
+  @changeStatus={{this.changeStatus}} 
   @isStatusUpdating={{this.isStatusUpdating}}
+  @updateStatus={{this.updateStatus}}
 />
 <UserStatusModal
   @isStatusUpdating={{this.isStatusUpdating}}

--- a/tests/integration/components/user-status-modal-test.js
+++ b/tests/integration/components/user-status-modal-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { click, render, fillIn } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
-module.only('Integration | Component | user-status-modal', function (hooks) {
+module('Integration | Component | user-status-modal', function (hooks) {
   setupRenderingTest(hooks);
 
   test('modal is visible if showModal is true', async function (assert) {
@@ -121,40 +121,7 @@ module.only('Integration | Component | user-status-modal', function (hooks) {
             @updateStatus={{this.updateStatus}}
             
         />`);
-    await fillIn('[data-test-date-picker-from]', '2022-12-02');
     await fillIn('[data-test-textarea-reason]', 'Rust and GoLang');
-    await click('.modal__submit');
-  });
-
-  test('payload contains relevant data when status is changed to ACTIVE', async function (assert) {
-    this.setProperties({
-      newStatus: 'ACTIVE',
-      showUserStateModal: true,
-      toggleUserStateModal: () => {
-        this.set('showUserStateModal', !this.showUserStateModal);
-      },
-      updateStatus: (statusPayLoad) => {
-        const {
-          currentStatus: { state, from, updatedAt },
-        } = statusPayLoad;
-        assert.equal(state, 'ACTIVE', 'new state present in the payload');
-        assert.ok(typeof from === 'number', 'from is a numeric timestamp');
-        assert.ok(
-          typeof updatedAt === 'number',
-          'updatedAt is a numeric timestamp'
-        );
-      },
-    });
-
-    await render(hbs`
-        <UserStatusModal 
-            @showUserStateModal={{this.showUserStateModal}}
-            @newStatus={{this.newStatus}}
-            @toggleUserStateModal={{this.toggleUserStateModal}}
-            @updateStatus={{this.updateStatus}}
-        />`);
-
-    await fillIn('[data-test-date-picker-from]', '2022-12-02');
     await click('.modal__submit');
   });
 


### PR DESCRIPTION
Closes all the points in https://github.com/Real-Dev-Squad/website-my/issues/340 except the 3rd one realted to future status.

- [x] Currently, Users can select any date while marking themselves as `Idle or Active`. We need to remove the `from date` field for `Idle or Active`. The `from date` field value will be the date on which they mark themselves as `Idle or Active`.  
- [x] Submit Button to enable only when all the mandatory fields are selected 
- [ ] If the users mark themselves `OOO` for a Future Date. It overrides the current status and shows `You are OOO`. It should show `OOO` only once the date arrives. Handle this case and also figure out what happens once the user is back in the office. 
- [x] If the Users are `OOO` for less than 3 days `Reason` shouldn't be mandatory. 
- [x] Disable past date selection for `OOO`

The remaining point 3 will be fixed in the future PR

[screen-capture.webm](https://user-images.githubusercontent.com/97341921/208008851-eb47f3c0-96dd-4b9c-865a-776f043f943e.webm)
