### PR TITLE
Hotfix Incorrect current status when updating a future OOO Status

### DIFF
--- a/app/components/user-status-modal.js
+++ b/app/components/user-status-modal.js
@@ -82,7 +82,9 @@ export default class FormStatusModal extends Component {
         return;
       }
     } else if (this.args.newStatus === USER_STATES.IDLE) {
-      from = Date.now();
+      const currentDate = new Date();
+      const currentDateString = currentDate.toISOString().slice(0, 10);
+      from = getUTCMidnightTimestampFromDate(currentDateString);
       if (!this.reason.length) {
         this.toast.error(
           WARNING_MESSAGE_FOR_IDLE,

--- a/app/components/user-status-modal.js
+++ b/app/components/user-status-modal.js
@@ -15,6 +15,7 @@ import {
   UNTIL_DATE,
   REASON,
 } from '../constants/user-status';
+import { getUTCMidnightTimestampFromDate } from '../utils/date-conversion';
 
 export default class FormStatusModal extends Component {
   @service toast;
@@ -68,8 +69,8 @@ export default class FormStatusModal extends Component {
         );
         return;
       }
-      from = new Date(this.fromDate.replaceAll('-', ',')).getTime();
-      until = new Date(this.untilDate.replaceAll('-', ',')).getTime();
+      from = getUTCMidnightTimestampFromDate(this.fromDate);
+      until = getUTCMidnightTimestampFromDate(this.untilDate);
       const isReasonReq = !this.checkIfFromToDatesAreClose();
 
       if (isReasonReq && !this.reason.length) {

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -1,6 +1,7 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { USER_STATES } from '../constants/user-status';
+import { getUTCMidnightTimestampFromDate } from '../utils/date-conversion';
 export default class UserStatusComponent extends Component {
   ALL_FEASIBLE_STATUS = {
     [USER_STATES.ACTIVE]: {
@@ -57,10 +58,13 @@ export default class UserStatusComponent extends Component {
 
   @action async changeStatus(status) {
     if (status === USER_STATES.ACTIVE) {
+      const currentDate = new Date();
+      const currentDateString = currentDate.toISOString().slice(0, 10);
+      const from = getUTCMidnightTimestampFromDate(currentDateString);
       const updatedAt = Date.now();
       const activeStateData = {
         updatedAt,
-        from: updatedAt,
+        from,
         until: undefined,
         message: undefined,
         state: USER_STATES.ACTIVE,

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -37,6 +37,17 @@ export default class IndexController extends Controller {
         .then((responseData) => {
           if (responseData.data.currentStatus?.state) {
             this.status = responseData.data.currentStatus.state;
+            this.toast.success(
+              'Current status updated successfully.',
+              '',
+              toastNotificationTimeoutOptions
+            );
+          } else if (responseData.data.futureStatus?.state) {
+            this.toast.success(
+              'Future status updated successfully.',
+              '',
+              toastNotificationTimeoutOptions
+            );
           }
         });
     } catch (error) {

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -25,28 +25,24 @@ export default class IndexController extends Controller {
       this.toggleUserStateModal();
     }
     try {
-      const response = await fetch(`${BASE_URL}/users/status/self`, {
+      await fetch(`${BASE_URL}/users/status/self`, {
         method: 'PATCH',
         body: JSON.stringify(newStatus),
         headers: {
           'Content-Type': 'application/json',
         },
         credentials: 'include',
-      });
-      const { status, statusText } = response;
-      if (status === 200) {
-        this.status = newStatus.currentStatus.state;
-      } else {
-        this.toast.error(
-          `${statusText}. Status Update failed`,
-          '',
-          toastNotificationTimeoutOptions
-        );
-      }
+      })
+        .then((response) => response.json())
+        .then((responseData) => {
+          if (responseData.data.currentStatus?.state) {
+            this.status = responseData.data.currentStatus.state;
+          }
+        });
     } catch (error) {
       console.error('Error : ', error);
       this.toast.error(
-        'Something went wrong.',
+        'Status Update failed. Something went wrong.',
         '',
         toastNotificationTimeoutOptions
       );

--- a/app/utils/date-conversion.js
+++ b/app/utils/date-conversion.js
@@ -1,0 +1,5 @@
+export const getUTCMidnightTimestampFromDate = (dateString) => {
+  const [year, month, day] = dateString.split('-').map((str) => parseInt(str));
+  const inputDate = new Date(Date.UTC(year, month - 1, day, 0, 0, 0));
+  return inputDate.getTime();
+};


### PR DESCRIPTION
- [x] Fix the error which was showing wrong status when updating future OOO Status.

Cause :
Instead of reading from API response we were reading from the input parameter which was causing the error. Now we read from the api response instead of input params.

**Dev Tested**
- [x] Yes
- [ ] No

**Browser**
- [x] Chrome
- [ ] Firefox
- [ ] MS Edge

[screen-capture (2).webm](https://user-images.githubusercontent.com/97341921/219104439-00772c2e-9042-4002-8695-e1c511155d00.webm)
