### PR TITLE
add a checkbox for userconsent in discord authorization page

### DIFF
--- a/app/controllers/discord.js
+++ b/app/controllers/discord.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import ENV from 'website-my/config/environment';
+import { toastNotificationTimeoutOptions } from '../constants/toast-notification';
 import { inject as service } from '@ember/service';
 import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
@@ -36,7 +37,10 @@ export default class DiscordController extends Controller {
           this.linkStatus = 'failure';
         }
       } else {
-        alert('Please provide your consent by clicking the checkbox');
+        this.toast.error(
+          'Please provide the consent by clicking the checkbox',
+          toastNotificationTimeoutOptions
+        );
       }
     } catch (error) {
       this.linkStatus = 'failure';

--- a/app/controllers/discord.js
+++ b/app/controllers/discord.js
@@ -39,6 +39,7 @@ export default class DiscordController extends Controller {
       } else {
         this.toast.error(
           'Please provide the consent by clicking the checkbox',
+          'ERROR',
           toastNotificationTimeoutOptions
         );
       }

--- a/app/controllers/discord.js
+++ b/app/controllers/discord.js
@@ -10,24 +10,33 @@ export default class DiscordController extends Controller {
     this.model.externalAccountData.attributes.discordId || '';
   @tracked linkStatus = 'not-linked';
   @tracked isLinking = false;
+  @tracked consent = false;
+
+  @action setConsent() {
+    this.consent = !this.consent;
+  }
 
   @action async linkDiscordAccount() {
     try {
       this.isLinking = true;
 
-      const response = await fetch(`${ENV.BASE_API_URL}/users/self`, {
-        method: 'PATCH',
-        body: JSON.stringify({ discordId: this.discordId }),
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-      });
+      if (this.consent) {
+        const response = await fetch(`${ENV.BASE_API_URL}/users/self`, {
+          method: 'PATCH',
+          body: JSON.stringify({ discordId: this.discordId }),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          credentials: 'include',
+        });
 
-      if (response.status === 204) {
-        this.linkStatus = 'linked';
+        if (response.status === 204) {
+          this.linkStatus = 'linked';
+        } else {
+          this.linkStatus = 'failure';
+        }
       } else {
-        this.linkStatus = 'failure';
+        alert('Please provide your consent by clicking the checkbox');
       }
     } catch (error) {
       this.linkStatus = 'failure';

--- a/app/controllers/discord.js
+++ b/app/controllers/discord.js
@@ -38,7 +38,7 @@ export default class DiscordController extends Controller {
         }
       } else {
         this.toast.error(
-          'Please provide the consent by clicking the checkbox',
+          'Please provide the consent by clicking the checkbox!',
           'ERROR',
           toastNotificationTimeoutOptions
         );

--- a/app/styles/discord.css
+++ b/app/styles/discord.css
@@ -73,3 +73,13 @@
   font-weight: 700;
   border-radius: 8px;
 }
+
+.btn-enabled {
+  color: var(--button--small--bg);
+  background-color: var(--button--small--text);
+}
+
+.btn-disabled {
+  color: var(--fetch--button--color);
+  background-color: var(--fetch--button--bg--disabled);
+}

--- a/app/templates/discord.hbs
+++ b/app/templates/discord.hbs
@@ -42,12 +42,9 @@
           <input name="authorize" id="authorize" type="checkbox" {{on 'input' (fn this.setConsent)}} />
           <label for="authorize">I Authorize Real Dev squad to change my nickname in their server.</label>
         </div>
-        
-        {{#if this.consent}}
-          <button type="button" class="discord__btn btn-enabled" {{on 'click' (fn this.linkDiscordAccount)}}>Authorize</button>
-        {{else}}
-          <button type="button" class="discord__btn btn-disabled" {{on 'click' (fn this.linkDiscordAccount)}}>Authorize</button>
-        {{/if}}
+
+        <button type="button" class="discord__btn {{if this.consent 'btn-enabled' 'btn-disabled'}}" {{on 'click' (fn this.linkDiscordAccount)}}>Authorize</button> 
+               
       {{/if}}
     {{/if}}
   {{/if}}

--- a/app/templates/discord.hbs
+++ b/app/templates/discord.hbs
@@ -35,7 +35,6 @@
             <p class="card-data__username">{{@model.userData.username}}</p>
             <p class="card-data__account">Real Dev Squad</p>
           </div>
-  
         </div>
 
         <div>
@@ -44,7 +43,7 @@
         </div>
 
         <button type="button" class="discord__btn {{if this.consent 'btn-enabled' 'btn-disabled'}}" {{on 'click' (fn this.linkDiscordAccount)}}>Authorize</button> 
-               
+
       {{/if}}
     {{/if}}
   {{/if}}

--- a/app/templates/discord.hbs
+++ b/app/templates/discord.hbs
@@ -35,9 +35,19 @@
             <p class="card-data__username">{{@model.userData.username}}</p>
             <p class="card-data__account">Real Dev Squad</p>
           </div>
+  
+        </div>
+
+        <div>
+          <input name="authorize" id="authorize" type="checkbox" {{on 'input' (fn this.setConsent)}} />
+          <label for="authorize">I Authorize Real Dev squad to change my nickname in their server.</label>
         </div>
         
-        <button type="button" class="discord__btn" {{on 'click' (fn this.linkDiscordAccount)}}>Authorize</button>
+        {{#if this.consent}}
+          <button type="button" class="discord__btn btn-enabled" {{on 'click' (fn this.linkDiscordAccount)}}>Authorize</button>
+        {{else}}
+          <button type="button" class="discord__btn btn-disabled" {{on 'click' (fn this.linkDiscordAccount)}}>Authorize</button>
+        {{/if}}
       {{/if}}
     {{/if}}
   {{/if}}

--- a/app/templates/discord.hbs
+++ b/app/templates/discord.hbs
@@ -1,4 +1,4 @@
-{{page-title "Discord"}}s
+{{page-title "Discord"}}
 
 <section class="discord">
   {{#if @model.isTokenExpired}}


### PR DESCRIPTION
This Pr adds a checkbox that takes in user consent to change their nickname in RDS discord server.

Submitting before checking the checkbox
![image](https://github.com/Real-Dev-Squad/website-my/assets/57758447/44a5bb88-d2c0-4954-939a-7d0dd6217875)

button enabled after checking the checkbox
![image](https://github.com/Real-Dev-Squad/website-my/assets/57758447/bf57c587-bdc0-49f2-8845-882ac7260edd)
