### PR TITLE
Show success alert on successful task update and remove `merge` option from select.

### DIFF
--- a/app/constants/tasks.js
+++ b/app/constants/tasks.js
@@ -9,7 +9,6 @@ const TASK_KEYS = {
   NEEDS_REVIEW: 'NEEDS_REVIEW',
   IN_REVIEW: 'IN_REVIEW',
   APPROVED: 'APPROVED',
-  MERGED: 'MERGED',
   SANITY_CHECK: 'SANITY_CHECK',
   REGRESSION_CHECK: 'REGRESSION_CHECK',
   RELEASED: 'RELEASED',
@@ -27,7 +26,6 @@ const {
   NEEDS_REVIEW,
   IN_REVIEW,
   APPROVED,
-  MERGED,
   SANITY_CHECK,
   REGRESSION_CHECK,
   RELEASED,
@@ -74,10 +72,6 @@ const TASK_STATUS_LIST = [
   {
     displayLabel: 'Approved',
     key: APPROVED,
-  },
-  {
-    displayLabel: 'Merged',
-    key: MERGED,
   },
   {
     displayLabel: 'Sanity Check',

--- a/app/controllers/tasks.js
+++ b/app/controllers/tasks.js
@@ -149,7 +149,11 @@ export default class TasksController extends Controller {
         });
 
         if (response.ok) {
-          this.showModal = true;
+          this.toast.success('Successfully updated the task', '', {
+            timeOut: '3000',
+            extendedTimeOut: '0',
+            preventDuplicates: false,
+          });
           const res = await response.json();
           const { message } = res;
           this.message = message;

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -43,7 +43,7 @@
     0 6px 20px 0 var(--task-card--box-shadow-2--hover);
 }
 
-#toast-container .toast {
+.toast {
   opacity: 0.9;
 }
 

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -43,6 +43,10 @@
     0 6px 20px 0 var(--task-card--box-shadow-2--hover);
 }
 
+#toast-container .toast {
+  opacity: 0.9;
+}
+
 .dates-info {
   text-align: center;
 }
@@ -416,7 +420,7 @@ input[type='range']:focus::-ms-fill-upper {
   padding: 5px 9px;
 }
 
-.extension-form__container-close:disabled{
+.extension-form__container-close:disabled {
   opacity: 0.7;
   background-color: #888;
 }
@@ -459,7 +463,7 @@ input[type='range']:focus::-ms-fill-upper {
     margin-top: 1rem;
   }
 
-  .extension-form__container-main{
+  .extension-form__container-main {
     left: 10px;
     right: 10px;
   }

--- a/tests/integration/components/select-input-test.js
+++ b/tests/integration/components/select-input-test.js
@@ -37,7 +37,9 @@ module('Integration | Component | select-input', function (hooks) {
     const selectOptions = find('#task-update').querySelectorAll('option');
     const firstOption = selectOptions[0];
     await click(firstOption);
-    assert.dom(selectElement).hasValue('AVAILABLE');
+
+    assert.dom(selectElement).hasValue(TASK_STATUS_LIST[1].key);
+
     assert.equal(
       selectOptions.length,
       this.availabletaskStatusList.length - 1,

--- a/tests/integration/components/select-input-test.js
+++ b/tests/integration/components/select-input-test.js
@@ -1,0 +1,44 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render, find } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { TASK_STATUS_LIST, TASK_KEYS } from 'website-my/constants/tasks';
+
+module('Integration | Component | select-input', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('render select-input', async function (assert) {
+    this.set('availabletaskStatusList', TASK_STATUS_LIST);
+    this.set('TASK_KEYS', TASK_KEYS);
+
+    this.set('onStatusChange', function () {});
+    this.set('onTaskUpdate', function () {});
+
+    await render(hbs`
+      <select
+        id='task-update'
+        onchange={{action this.onStatusChange}}
+        onchange={{action this.onTaskUpdate @task.id}}
+      >
+        {{#each this.availabletaskStatusList as |taskStatus|}}
+          {{#if (not-eq taskStatus.key this.TASK_KEYS.ALL)}}
+            <option value={{taskStatus.key}}>
+              {{taskStatus.displayLabel}}
+            </option>
+          {{/if}}
+        {{/each}}
+      </select>
+    `);
+
+    // Assert
+    assert.dom('select').exists();
+
+    const selectOptions = find('#task-update').querySelectorAll('option');
+
+    assert.equal(
+      selectOptions.length,
+      this.availabletaskStatusList.length - 1,
+      'Correct number of options are rendered'
+    );
+  });
+});

--- a/tests/integration/components/select-input-test.js
+++ b/tests/integration/components/select-input-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render, find } from '@ember/test-helpers';
+import { render, find, click } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { TASK_STATUS_LIST, TASK_KEYS } from 'website-my/constants/tasks';
 
@@ -33,8 +33,11 @@ module('Integration | Component | select-input', function (hooks) {
     // Assert
     assert.dom('select').exists();
 
+    const selectElement = this.element.querySelector('#task-update');
     const selectOptions = find('#task-update').querySelectorAll('option');
-
+    const firstOption = selectOptions[0];
+    await click(firstOption);
+    assert.dom(selectElement).hasValue('AVAILABLE');
     assert.equal(
       selectOptions.length,
       this.availabletaskStatusList.length - 1,


### PR DESCRIPTION
## ISSUE: https://github.com/Real-Dev-Squad/website-my/issues/417
This PR does the following changes:
1.  ### Show `success` alert on successful taskupdate and not show modal.
**Before**: 
![image](https://github.com/Real-Dev-Squad/website-my/assets/68814457/489a4478-2506-4d64-bb97-1e4d99807c44)
**After**:
<img width="1437" alt="image" src="https://github.com/Real-Dev-Squad/website-my/assets/68814457/f4443fd2-10dd-47a7-b4f2-53bcfa5b45bf">

2.   ### Remove `merge` option from select component as user cannot update any task to `merge` status directly. Only `superuser` can do it from status site. 
