### PR TITLE
Fix: Task Status Update to VERIFIED Issue

### DIFF
--- a/app/components/task/holder.hbs
+++ b/app/components/task/holder.hbs
@@ -27,7 +27,6 @@
           data-test-task-status-select
           id='task-update'
           {{on 'change' this.onStatusChange}}
-          {{on 'change' (fn this.onUpdate @task.id)}}
         >
           {{#each this.availabletaskStatusList as |taskStatus|}}
             {{#if (not-eq taskStatus.key this.TASK_KEYS.ALL)}}

--- a/app/components/task/holder.js
+++ b/app/components/task/holder.js
@@ -95,6 +95,7 @@ export default class TasksHolderComponent extends Component {
     const { value } = e.target;
     this.status = value;
     this.args.onTaskChange('status', value);
+    this.onUpdate(this.args.task.id);
   }
 
   @action

--- a/tests/integration/components/tasks/holder-test.js
+++ b/tests/integration/components/tasks/holder-test.js
@@ -218,7 +218,7 @@ module('Integration | Component | Tasks Holder', function (hooks) {
     let onTaskUpdateCalled = 0;
 
     this.set('task', testTask);
-    this.set('onTaskUpdate', (taskId, error) => {
+    this.set('onTaskUpdate', () => {
       onTaskUpdateCalled++;
     });
     this.set('mock', () => {});

--- a/tests/integration/components/tasks/holder-test.js
+++ b/tests/integration/components/tasks/holder-test.js
@@ -209,4 +209,37 @@ module('Integration | Component | Tasks Holder', function (hooks) {
       .dom('[data-test-task-status-select]')
       .hasValue(TASK_KEYS.IN_PROGRESS);
   });
+
+  test('Verify status change to VERIFIED', async function (assert) {
+    const testTask = tasksData[3];
+
+    testTask.status = TASK_KEYS.IN_PROGRESS;
+
+    let onTaskUpdateCalled = 0;
+
+    this.set('task', testTask);
+    this.set('onTaskUpdate', (taskId, error) => {
+      onTaskUpdateCalled++;
+    });
+    this.set('mock', () => {});
+    this.set('isLoading', false);
+    this.set('disabled', false);
+    this.set('defaultType', DEFAULT_TASK_TYPE);
+
+    await render(hbs`<Task::Holder
+    @task={{this.task}}
+    @onTaskUpdate={{onTaskUpdate}}
+    @onTaskChange={{this.mock}}
+    @userSelectedTask={{this.defaultType}}
+    @disabled={{this.disabled}}
+  />`);
+
+    assert
+      .dom('[data-test-task-status-select]')
+      .hasValue(TASK_KEYS.IN_PROGRESS);
+
+    await select('[data-test-task-status-select]', TASK_KEYS.VERIFIED);
+
+    assert.equal(onTaskUpdateCalled, 1, 'onTaskUpdate should be called once');
+  });
 });


### PR DESCRIPTION
Fixes: #456 

Description: 
This PR fixes an issue where user was not able to their tasks in tasks page to VERIFIED status.



Video: 

https://github.com/Real-Dev-Squad/website-my/assets/98796547/0bbaa884-9b1f-4db2-9b2f-9351bb19cddc


