### PR TITLE
Set in_discord to true and archived to false upon user verification

### DIFF
--- a/app/controllers/discord.js
+++ b/app/controllers/discord.js
@@ -24,7 +24,10 @@ export default class DiscordController extends Controller {
       if (this.consent) {
         const response = await fetch(`${ENV.BASE_API_URL}/users/self`, {
           method: 'PATCH',
-          body: JSON.stringify({ discordId: this.discordId }),
+          body: JSON.stringify({
+            discordId: this.discordId,
+            roles: { archived: false, in_discord: true },
+          }),
           headers: {
             'Content-Type': 'application/json',
           },


### PR DESCRIPTION
## Description
Currently, when users verify themselves, their account properties are not being appropriately updated in our system. To ensure accurate user management, we need to implement changes that set the "archived" property to false and the "in_discord" property to true for users upon successful verification.

## Issue
https://github.com/Real-Dev-Squad/website-backend/issues/1394

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Testing

- [x] Is dev tested
- [ ] Is not dev tested
 
### Testing details
User data before fix
```
{
   "created_at" : 1693847322484,
   "discordId" : "232533446310887426",
   "github_created_at" : 1490287565000,
   "github_display_name" : "Shardul Silswal",
   "github_id" : "shardul08",
   "incompleteUserDetails" : true,
   "roles" : {
      "archived" : false,
      "in_discord " : false
   },
   "updated_at" : 1693847591891
}
```

User data after the fix
```
{
   "created_at" : 1693849176847,
   "discordId" : "232533446310887426",
   "github_created_at" : 1490287565000,
   "github_display_name" : "Shardul Silswal",
   "github_id" : "shardul08",
   "incompleteUserDetails" : true,
   "roles" : {
      "archived" : false,
      "in_discord" : true
   },
   "updated_at" : 1693849218964
}
```

