### PR TITLE
Assetlinks Json for deeplink

### DIFF
--- a/public/.well-known/assetlinks.json
+++ b/public/.well-known/assetlinks.json
@@ -1,0 +1,14 @@
+[
+    {
+        "relation": [
+            "delegate_permission/common.handle_all_urls"
+        ],
+        "target": {
+            "namespace": "android_app",
+            "package_name": "com.rdsapp",
+            "sha256_cert_fingerprints": [
+                "FA:C6:17:45:DC:09:03:78:6F:B9:ED:E6:2A:96:2B:39:9F:73:48:F0:BB:6F:89:9B:83:32:66:75:91:03:3B:9C"
+            ]
+        }
+    }
+]


### PR DESCRIPTION
**Why do we need this?**

We are implementing SignIn with github in mobile so we need the deeplink to be implemented in website for the redirect back to mobile app.


**What is the change?**

Added assetlinks.json file for mobile app verification and redirecting it to mobile app from new signUp flow site in case of signInwith github login from mobile.
