### PR TITLE
Feat/allow multiple extension requests

### DIFF
--- a/app/components/task/holder.hbs
+++ b/app/components/task/holder.hbs
@@ -14,12 +14,21 @@
   <div class='task-card__status-update-container'>
 
     {{#if this.extensionFormOpened}}
-      <Task::ExtensionForm
-        @task={{@task}}
-        @closeForm={{this.closeExtensionForm}}
-        @title='Form for extension Request'
-        @closeModel={{this.closeExtensionModel}}
-      />
+      {{#if @dev}}
+        <Task::MultipleExtensionForm
+          @task={{@task}}
+          @closeForm={{this.closeExtensionForm}}
+          @title='Form for extension Request'
+          @closeModel={{this.closeExtensionModel}}
+        />
+      {{else}}
+        <Task::ExtensionForm
+          @task={{@task}}
+          @closeForm={{this.closeExtensionForm}}
+          @title='Form for extension Request'
+          @closeModel={{this.closeExtensionModel}}
+        />
+      {{/if}}
     {{/if}}
 
     {{#if (not-eq this.status this.TASK_KEYS.VERIFIED)}}

--- a/app/components/task/holder.hbs
+++ b/app/components/task/holder.hbs
@@ -18,7 +18,7 @@
         <Task::MultipleExtensionForm
           @task={{@task}}
           @closeForm={{this.closeExtensionForm}}
-          @title='Form for extension Request'
+          @title='Extension Details'
           @closeModel={{this.closeExtensionModel}}
         />
       {{else}}

--- a/app/components/task/holder.js
+++ b/app/components/task/holder.js
@@ -9,6 +9,7 @@ export default class TasksHolderComponent extends Component {
   @tracked status = this.args.task.status;
   @tracked extensionFormOpened = false;
   @tracked isLoading = false;
+  queryParams = ['dev'];
 
   TASK_KEYS = TASK_KEYS;
   availabletaskStatusList = TASK_STATUS_LIST;

--- a/app/components/task/latest-extension-info.hbs
+++ b/app/components/task/latest-extension-info.hbs
@@ -1,33 +1,33 @@
-<div class='extension-info__content' data-test-extension-info-content>
+<div class='latest-extension-info__content' data-test-extension-info-content>
   <table>
     <tbody>
       <tr>
-        <th>Request no</th>
+        <th>Request : </th>
         <td>{{#if (eq this.extension.requestNumber undefined)}}
-            1
+           #1
           {{else}}
-            {{this.extension.requestNumber}}
+           #{{this.extension.requestNumber}}
           {{/if}}
         </td>
       </tr>
       <tr>
-        <th>Reason</th>
+        <th>Reason : </th>
         <td>{{this.extension.reason}}</td>
       </tr>
       <tr>
-        <th>Title</th>
+        <th>Title : </th>
         <td>{{this.extension.title}}</td>
       </tr>
       <tr>
-        <th>Old Ends On</th>
+        <th>Old Ends On : </th>
         <td>{{this.oldEndsOn}}</td>
       </tr>
       <tr>
-        <th>New Ends On</th>
+        <th>New Ends On : </th>
         <td>{{this.newEndsOn}}</td>
       </tr>
       <tr>
-        <th>Status</th>
+        <th>Status : </th>
         <td>{{this.extension.status}}</td>
       </tr>
     </tbody>

--- a/app/components/task/latest-extension-info.hbs
+++ b/app/components/task/latest-extension-info.hbs
@@ -1,6 +1,6 @@
 <div class='latest-extension-info__content' data-test-extension-info-content>
-  <table>
-    <tbody>
+  <table class="latest-table">
+    <tbody class="latest-table">
       <tr>
         <th>Request : </th>
         <td>{{#if (eq this.extension.requestNumber undefined)}}
@@ -11,7 +11,7 @@
         </td>
       </tr>
       <tr>
-        <th class="extension-reason">Reason : </th>
+        <th >Reason : </th>
         <td>{{this.extension.reason}}</td>
       </tr>
       <tr>

--- a/app/components/task/latest-extension-info.hbs
+++ b/app/components/task/latest-extension-info.hbs
@@ -11,7 +11,7 @@
         </td>
       </tr>
       <tr>
-        <th>Reason : </th>
+        <th class="extension-reason">Reason : </th>
         <td>{{this.extension.reason}}</td>
       </tr>
       <tr>

--- a/app/components/task/latest-extension-info.hbs
+++ b/app/components/task/latest-extension-info.hbs
@@ -1,0 +1,35 @@
+<div class='extension-info__content' data-test-extension-info-content>
+  <table>
+    <tbody>
+      <tr>
+        <th>Request no</th>
+        <td>{{#if (eq this.extension.requestNumber undefined)}}
+            1
+          {{else}}
+            {{this.extension.requestNumber}}
+          {{/if}}
+        </td>
+      </tr>
+      <tr>
+        <th>Reason</th>
+        <td>{{this.extension.reason}}</td>
+      </tr>
+      <tr>
+        <th>Title</th>
+        <td>{{this.extension.title}}</td>
+      </tr>
+      <tr>
+        <th>Old Ends On</th>
+        <td>{{this.oldEndsOn}}</td>
+      </tr>
+      <tr>
+        <th>New Ends On</th>
+        <td>{{this.newEndsOn}}</td>
+      </tr>
+      <tr>
+        <th>Status</th>
+        <td>{{this.extension.status}}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/app/components/task/latest-extension-info.js
+++ b/app/components/task/latest-extension-info.js
@@ -1,5 +1,4 @@
 import Component from '@glimmer/component';
-import { action } from '@ember/object';
 
 export default class LatestExtensionInfoComponent extends Component {
   extension = this.args.extension;
@@ -8,11 +7,5 @@ export default class LatestExtensionInfoComponent extends Component {
 
   localTime(time) {
     return new Date(time * 1000).toLocaleString();
-  }
-
-  @action
-  closeForm() {
-    // Call the closeForm action passed from the parent component
-    this.args.closeForm();
   }
 }

--- a/app/components/task/latest-extension-info.js
+++ b/app/components/task/latest-extension-info.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+
+export default class LatestExtensionInfoComponent extends Component {
+  extension = this.args.extension;
+  newEndsOn = this.localTime(this.extension.newEndsOn);
+  oldEndsOn = this.localTime(this.extension.oldEndsOn);
+
+  localTime(time) {
+    return new Date(time * 1000).toLocaleString();
+  }
+
+  @action
+  closeForm() {
+    // Call the closeForm action passed from the parent component
+    this.args.closeForm();
+  }
+}

--- a/app/components/task/multiple-extension-form.hbs
+++ b/app/components/task/multiple-extension-form.hbs
@@ -25,15 +25,15 @@
             </div>
           {{/if}}
           <label for='reason'>Reason</label>
-          <input
+          <textarea
             required
             type='text-box'
             id='reason'
             name='reason'
             data-test-extension-form-reason-input
           />
-          <label for='newEndsOn'>New ETA</label>
           <p>Old ETA - {{this.oldETA}}</p>
+          <label for='newEndsOn'>New ETA</label>
           <input
             required
             type='datetime-local'
@@ -43,14 +43,14 @@
             data-test-extension-form-newEndsOn-input
           />
           <label for='title'>Title</label>
-          <input
+          <textarea
             required
             type='text-box'
             id='title'
             name='title'
             data-test-extension-form-title-input
           />
-          <button class ='multiple-extension-form__create-button primary-button-style' type='submit'>Submit Request</button>
+          <button class ='multiple-extension-form__create-button primary-button-style' disabled={{this.isSubmitButtonDisabled}} type='submit'>Submit</button>
         </form>
       </div>
     {{else}}
@@ -72,7 +72,7 @@
             data-test-create-extension-button
             type='button'
             {{on 'click' this.createNewExtensionRequest}}
-          >Create an extension request</button>
+          >Create request</button>
         {{/if}}
       </div>
     {{/if}}
@@ -87,6 +87,7 @@
           class='multiple-extension-form__open-button primary-button-style'
           data-test-create-another-extension type="button" {{on 'click' this.createNewExtensionRequest}}
         >
+        
           Request Extension
         </button>
       {{/unless}}
@@ -100,7 +101,7 @@
       {{#if this.createExtensionRequest}}
         Cancel
       {{else}}
-        Close Details
+        Close
       {{/if}}
     </button>
   </div>

--- a/app/components/task/multiple-extension-form.hbs
+++ b/app/components/task/multiple-extension-form.hbs
@@ -7,19 +7,27 @@
   >
   </div>
   <div class='extension-form__container-main'>
-    <h2 data-test-title>{{@title}}</h2>
+    <h2 data-test-title>
+      {{#if this.createExtensionRequest}}
+        Extension Request Form
+      {{else}}
+        Extension Details
+      {{/if}}
+    </h2>
     {{#if this.createExtensionRequest}}
       <div class='extension-form__content' data-test-extension-from-content>
-        <h3>Create Extension Request!!!</h3>
+        {{!-- <h3>Create Extension Request!!!</h3> --}}
         <form {{on 'submit' this.submitExtensionRequest}}>
           {{#if this.createExtensionRequestError}}
-            <h4 data-test-extension-from-error>Error:
+            <div class="error-container">
+            <h4 class= "error-message" data-test-extension-from-error>Error:
               {{this.createExtensionRequestError}}</h4>
+            </div>
           {{/if}}
           <label for='reason'>Reason</label>
           <input
             required
-            type='text'
+            type='text-box'
             id='reason'
             name='reason'
             data-test-extension-form-reason-input
@@ -37,12 +45,12 @@
           <label for='title'>Title</label>
           <input
             required
-            type='text'
+            type='text-box'
             id='title'
             name='title'
             data-test-extension-form-title-input
           />
-          <button type='submit'>Create</button>
+          <button class ='multiple-extension-form__create-button primary-button-style' type='submit'>Submit Request</button>
         </form>
       </div>
     {{else}}
@@ -60,7 +68,7 @@
         {{else if this.extensionData.error}}
           <h4>{{this.extensionData.error}}</h4>
           <button
-            class='extension-form__open-button'
+            class='multiple-extension-form__open-button primary-button-style'
             data-test-create-extension-button
             type='button'
             {{on 'click' this.createNewExtensionRequest}}
@@ -76,20 +84,24 @@
     }}
       {{#unless this.createExtensionRequest}}
         <button
-          class='extension-form__open-button'
+          class='multiple-extension-form__open-button primary-button-style'
           data-test-create-another-extension type="button" {{on 'click' this.createNewExtensionRequest}}
         >
-          Create New Extension
+          Request Extension
         </button>
       {{/unless}}
     {{/if}}
     <button
-      class='extension-form__container-close'
+      class='multiple-extension-form__container-close'
       data-test-extension-form-container-close
       type='button'
       {{on 'click' @closeForm}}
     >
-      Close Form
+      {{#if this.createExtensionRequest}}
+        Cancel
+      {{else}}
+        Close Details
+      {{/if}}
     </button>
   </div>
 </div>

--- a/app/components/task/multiple-extension-form.hbs
+++ b/app/components/task/multiple-extension-form.hbs
@@ -1,11 +1,10 @@
 <div class='extension-form__container-parent'>
   <div
-    role='button'
+    role='button' id='create'
     class='extension-form__container-back'
     data-test-extension-form-container-back
     {{on 'click' @closeModel}}
-  >
-  </div>
+  ></div>
   <div class='extension-form__container-main'>
     <h2 data-test-title>
       {{#if this.createExtensionRequest}}
@@ -16,14 +15,7 @@
     </h2>
     {{#if this.createExtensionRequest}}
       <div class='extension-form__content' data-test-extension-from-content>
-        {{!-- <h3>Create Extension Request!!!</h3> --}}
         <form {{on 'submit' this.submitExtensionRequest}}>
-          {{#if this.createExtensionRequestError}}
-            <div class="error-container">
-            <h4 class= "error-message" data-test-extension-from-error>Error:
-              {{this.createExtensionRequestError}}</h4>
-            </div>
-          {{/if}}
           <label for='reason'>Reason</label>
           <textarea
             required
@@ -31,7 +23,7 @@
             id='reason'
             name='reason'
             data-test-extension-form-reason-input
-          />
+          ></textarea>
           <p>Old ETA - {{this.oldETA}}</p>
           <label for='newEndsOn'>New ETA</label>
           <input
@@ -49,8 +41,26 @@
             id='title'
             name='title'
             data-test-extension-form-title-input
-          />
-          <button class ='multiple-extension-form__create-button primary-button-style' disabled={{this.isSubmitButtonDisabled}} type='submit'>Submit</button>
+          ></textarea>
+          <div class="error-container" id='error'>
+          <span class='error-placeholder' data-test-extension-from-error></span>
+          </div>
+          <div class='buttons' id='form'>
+          <button
+            class='multiple-extension-form__container-close'
+            data-test-extension-form-container-close
+            type='button'
+            {{on 'click' @closeForm}}
+          >
+            Cancel
+          </button>
+
+          <button
+            class='multiple-extension-form__create-button primary-button-style'
+            disabled={{this.isSubmitButtonDisabled}}
+            type='submit'
+          >Submit</button>
+          </div>
         </form>
       </div>
     {{else}}
@@ -61,48 +71,53 @@
               <Task::LatestExtensionInfo @extension={{extension}} />
             {{/each}}
           </div>
+          <div class='buttons' id='detail'>
+          <button
+            class='multiple-extension-form__container-close'
+            data-test-extension-form-container-close
+            type='button'
+            {{on 'click' @closeForm}}
+          >
+            Close
+          </button>
+          
+          {{#if (or (eq this.previousExtensionStatus 'APPROVED') (eq this.previousExtensionStatus 'DENIED'))}}
+            <button
+              class='multiple-extension-form__open-button primary-button-style'
+              data-test-create-another-extension
+              type='button'
+              {{on 'click' this.createNewExtensionRequest}}
+            >
+              Request Extension
+            </button>
+          {{/if}}
+          </div>
         {{else if this.extensionData.isLoading}}
           <div class='task-card__loader-container'>
             <Spinner />
           </div>
         {{else if this.extensionData.error}}
           <h4>{{this.extensionData.error}}</h4>
+          <div class='buttons' id='create'>
+          <button
+            class='multiple-extension-form__container-close'
+            data-test-extension-form-container-close
+            type='button'
+            {{on 'click' @closeForm}}
+          >
+            Close
+          </button>
           <button
             class='multiple-extension-form__open-button primary-button-style'
             data-test-create-extension-button
             type='button'
             {{on 'click' this.createNewExtensionRequest}}
-          >Create request</button>
+          >
+            Request Extension
+          </button>
+          </div>
         {{/if}}
       </div>
     {{/if}}
-    {{#if
-      (or
-        (eq this.previousExtensionStatus 'APPROVED')
-        (eq this.previousExtensionStatus 'DENIED')
-      )
-    }}
-      {{#unless this.createExtensionRequest}}
-        <button
-          class='multiple-extension-form__open-button primary-button-style'
-          data-test-create-another-extension type="button" {{on 'click' this.createNewExtensionRequest}}
-        >
-        
-          Request Extension
-        </button>
-      {{/unless}}
-    {{/if}}
-    <button
-      class='multiple-extension-form__container-close'
-      data-test-extension-form-container-close
-      type='button'
-      {{on 'click' @closeForm}}
-    >
-      {{#if this.createExtensionRequest}}
-        Cancel
-      {{else}}
-        Close
-      {{/if}}
-    </button>
   </div>
 </div>

--- a/app/components/task/multiple-extension-form.hbs
+++ b/app/components/task/multiple-extension-form.hbs
@@ -1,0 +1,95 @@
+<div class='extension-form__container-parent'>
+  <div
+    role='button'
+    class='extension-form__container-back'
+    data-test-extension-form-container-back
+    {{on 'click' @closeModel}}
+  >
+  </div>
+  <div class='extension-form__container-main'>
+    <h2 data-test-title>{{@title}}</h2>
+    {{#if this.createExtensionRequest}}
+      <div class='extension-form__content' data-test-extension-from-content>
+        <h3>Create Extension Request!!!</h3>
+        <form {{on 'submit' this.submitExtensionRequest}}>
+          {{#if this.createExtensionRequestError}}
+            <h4 data-test-extension-from-error>Error:
+              {{this.createExtensionRequestError}}</h4>
+          {{/if}}
+          <label for='reason'>Reason</label>
+          <input
+            required
+            type='text'
+            id='reason'
+            name='reason'
+            data-test-extension-form-reason-input
+          />
+          <label for='newEndsOn'>New ETA</label>
+          <p>Old ETA - {{this.oldETA}}</p>
+          <input
+            required
+            type='datetime-local'
+            id='newEndsOn'
+            name='newEndsOn'
+            {{on 'change' this.changeExtensionRequestETA}}
+            data-test-extension-form-newEndsOn-input
+          />
+          <label for='title'>Title</label>
+          <input
+            required
+            type='text'
+            id='title'
+            name='title'
+            data-test-extension-form-title-input
+          />
+          <button type='submit'>Create</button>
+        </form>
+      </div>
+    {{else}}
+      <div class='extension-form__content' data-test-extension-from-content>
+        {{#if this.extensionData.value}}
+          <div class='extension-form__content-wrapper'>
+            {{#each this.extensionData.value as |extension|}}
+              <Task::LatestExtensionInfo @extension={{extension}} />
+            {{/each}}
+          </div>
+        {{else if this.extensionData.isLoading}}
+          <div class='task-card__loader-container'>
+            <Spinner />
+          </div>
+        {{else if this.extensionData.error}}
+          <h4>{{this.extensionData.error}}</h4>
+          <button
+            class='extension-form__open-button'
+            data-test-create-extension-button
+            type='button'
+            {{on 'click' this.createNewExtensionRequest}}
+          >Create an extension request</button>
+        {{/if}}
+      </div>
+    {{/if}}
+    {{#if
+      (or
+        (eq this.previousExtensionStatus 'APPROVED')
+        (eq this.previousExtensionStatus 'DENIED')
+      )
+    }}
+      {{#unless this.createExtensionRequest}}
+        <button
+          class='extension-form__open-button'
+          data-test-create-another-extension type="button" {{on 'click' this.createNewExtensionRequest}}
+        >
+          Create New Extension
+        </button>
+      {{/unless}}
+    {{/if}}
+    <button
+      class='extension-form__container-close'
+      data-test-extension-form-container-close
+      type='button'
+      {{on 'click' @closeForm}}
+    >
+      Close Form
+    </button>
+  </div>
+</div>

--- a/app/components/task/multiple-extension-form.js
+++ b/app/components/task/multiple-extension-form.js
@@ -12,7 +12,6 @@ export default class ExtensionFormComponent extends Component {
   @tracked createExtensionRequest = false;
   @tracked createExtensionRequestError = null;
   @tracked disableExtensionRequestClose = false;
-  // Add a property to track the status of the previous extension request
   @tracked previousExtensionStatus = null;
   @tracked isSubmitButtonDisabled = false;
 
@@ -93,7 +92,6 @@ export default class ExtensionFormComponent extends Component {
     this.disableExtensionRequestClose = true;
     this.createExtensionRequestError = null;
     this.isSubmitButtonDisabled = true;
-    //submit button
     const formData = new FormData(e.target);
     const extensionTime = new Date(formData.get('newEndsOn')).getTime() / 1000;
     const json = {};
@@ -106,8 +104,6 @@ export default class ExtensionFormComponent extends Component {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
-
-      //e.submitter.disabled = false;
       this.disableExtensionRequestClose = false;
       this.createExtensionRequestError = 'New ETA must be greater than Old ETA';
       return;
@@ -139,20 +135,18 @@ export default class ExtensionFormComponent extends Component {
           ...toastNotificationTimeoutOptions,
           timeOut: '3000',
         });
-        setTimeout(this.args.closeModel, 2000);
+        setTimeout(this.args.closeModel, 1000);
         return;
       }
       this.toast.error('Something went wrong!', '', {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
-      //e.submitter.disabled = false;
     } catch (error) {
       this.toast.error(error.message, '', {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
-      setTimeout(this.args.closeModel, 2000);
     } finally {
       this.isSubmitButtonDisabled = false;
     }
@@ -160,34 +154,29 @@ export default class ExtensionFormComponent extends Component {
 
   @action
   changeExtensionRequestETA(e) {
+    const errorPlaceholder = document.querySelector('.error-placeholder');
     const extensionTime = new Date(e.target.value).getTime() / 1000;
-    // const submitButton = document.getElementById(
-    //   'extension-form-submit-button'
-    // );
     if (extensionTime < this.args.task.endsOn) {
       this.toast.error(WARNING_INVALID_NEW_ETA, '', {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
-
       this.isSubmitButtonDisabled = true;
-      //e.target.value = '';
-      // if (e.submitter && e.submitter.disabled !== undefined) {
-      //   e.submitter.disabled = true;
-      // }
-
-      // if (submitButton) {
-      //   submitButton.disabled = true;
-      // }
       this.createExtensionRequestError = 'New ETA must be greater than Old ETA';
-
+      errorPlaceholder.textContent = this.createExtensionRequestError;
+      errorPlaceholder.style.visibility = 'visible';
+      // errorContainer.style.height = '25px'; // Set the fixed height
+      // errorContainer.classList.add('show');
       return;
     } else {
       this.createExtensionRequestError = null;
       this.isSubmitButtonDisabled = false;
-      // if (submitButton) {
-      //   submitButton.disabled = false;
-      // }
+      errorPlaceholder.textContent = this.createExtensionRequestError;
+      errorPlaceholder.style.visibility = 'hidden';
+      //errorContainer.visibility='hidden';
+      // errorContainer.style.height = '0'; // Set the height to 0
+      // errorContainer.classList.remove('show');
+      return;
     }
   }
 }

--- a/app/components/task/multiple-extension-form.js
+++ b/app/components/task/multiple-extension-form.js
@@ -135,7 +135,11 @@ export default class ExtensionFormComponent extends Component {
           ...toastNotificationTimeoutOptions,
           timeOut: '3000',
         });
-        setTimeout(this.args.closeModel, 1000);
+        setTimeout(
+          (this.isSubmitButtonDisabled = true),
+          this.args.closeModel(),
+          2000
+        );
         return;
       }
       this.toast.error('Something went wrong!', '', {
@@ -165,17 +169,12 @@ export default class ExtensionFormComponent extends Component {
       this.createExtensionRequestError = 'New ETA must be greater than Old ETA';
       errorPlaceholder.textContent = this.createExtensionRequestError;
       errorPlaceholder.style.visibility = 'visible';
-      // errorContainer.style.height = '25px'; // Set the fixed height
-      // errorContainer.classList.add('show');
       return;
     } else {
       this.createExtensionRequestError = null;
       this.isSubmitButtonDisabled = false;
       errorPlaceholder.textContent = this.createExtensionRequestError;
       errorPlaceholder.style.visibility = 'hidden';
-      //errorContainer.visibility='hidden';
-      // errorContainer.style.height = '0'; // Set the height to 0
-      // errorContainer.classList.remove('show');
       return;
     }
   }

--- a/app/components/task/multiple-extension-form.js
+++ b/app/components/task/multiple-extension-form.js
@@ -108,7 +108,7 @@ export default class ExtensionFormComponent extends Component {
       e.submitter.disabled = false;
       this.disableExtensionRequestClose = false;
       this.createExtensionRequestError =
-        'The newEndsOn value cannot be smaller than the oldEndsOn value';
+        'New ETA must be later than the existing ETA.';
       return;
     }
     json['newEndsOn'] = extensionTime;
@@ -165,7 +165,7 @@ export default class ExtensionFormComponent extends Component {
       });
       e.target.value = '';
       this.createExtensionRequestError =
-        'The newEndsOn value cannot be smaller than the oldEndsOn value';
+        'New ETA must be later than the existing ETA.';
       return;
     } else this.createExtensionRequestError = null;
   }

--- a/app/components/task/multiple-extension-form.js
+++ b/app/components/task/multiple-extension-form.js
@@ -14,6 +14,7 @@ export default class ExtensionFormComponent extends Component {
   @tracked disableExtensionRequestClose = false;
   // Add a property to track the status of the previous extension request
   @tracked previousExtensionStatus = null;
+  @tracked isSubmitButtonDisabled = false;
 
   @service toast;
   @service userState;
@@ -91,8 +92,8 @@ export default class ExtensionFormComponent extends Component {
     e.preventDefault();
     this.disableExtensionRequestClose = true;
     this.createExtensionRequestError = null;
+    this.isSubmitButtonDisabled = true;
     //submit button
-    e.submitter.disabled = true;
     const formData = new FormData(e.target);
     const extensionTime = new Date(formData.get('newEndsOn')).getTime() / 1000;
     const json = {};
@@ -105,12 +106,13 @@ export default class ExtensionFormComponent extends Component {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
-      e.submitter.disabled = false;
+
+      //e.submitter.disabled = false;
       this.disableExtensionRequestClose = false;
-      this.createExtensionRequestError =
-        'New ETA must be later than the existing ETA.';
+      this.createExtensionRequestError = 'New ETA must be greater than Old ETA';
       return;
     }
+
     json['newEndsOn'] = extensionTime;
     //setting default values
     json['taskId'] = this.args.task.id;
@@ -144,29 +146,48 @@ export default class ExtensionFormComponent extends Component {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
-      e.submitter.disabled = false;
+      //e.submitter.disabled = false;
     } catch (error) {
       this.toast.error(error.message, '', {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
       setTimeout(this.args.closeModel, 2000);
+    } finally {
+      this.isSubmitButtonDisabled = false;
     }
   }
 
   @action
   changeExtensionRequestETA(e) {
     const extensionTime = new Date(e.target.value).getTime() / 1000;
-
+    // const submitButton = document.getElementById(
+    //   'extension-form-submit-button'
+    // );
     if (extensionTime < this.args.task.endsOn) {
       this.toast.error(WARNING_INVALID_NEW_ETA, '', {
         ...toastNotificationTimeoutOptions,
         timeOut: '3000',
       });
-      e.target.value = '';
-      this.createExtensionRequestError =
-        'New ETA must be later than the existing ETA.';
+
+      this.isSubmitButtonDisabled = true;
+      //e.target.value = '';
+      // if (e.submitter && e.submitter.disabled !== undefined) {
+      //   e.submitter.disabled = true;
+      // }
+
+      // if (submitButton) {
+      //   submitButton.disabled = true;
+      // }
+      this.createExtensionRequestError = 'New ETA must be greater than Old ETA';
+
       return;
-    } else this.createExtensionRequestError = null;
+    } else {
+      this.createExtensionRequestError = null;
+      this.isSubmitButtonDisabled = false;
+      // if (submitButton) {
+      //   submitButton.disabled = false;
+      // }
+    }
   }
 }

--- a/app/components/task/multiple-extension-form.js
+++ b/app/components/task/multiple-extension-form.js
@@ -1,0 +1,172 @@
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { resource, use } from 'ember-resources';
+import { TrackedMap } from 'tracked-maps-and-sets';
+import ENV from 'website-my/config/environment';
+import { action } from '@ember/object';
+import { WARNING_INVALID_NEW_ETA } from '../../constants/user-status';
+import { toastNotificationTimeoutOptions } from '../../constants/toast-notification';
+import { inject as service } from '@ember/service';
+
+export default class ExtensionFormComponent extends Component {
+  @tracked createExtensionRequest = false;
+  @tracked createExtensionRequestError = null;
+  @tracked disableExtensionRequestClose = false;
+  // Add a property to track the status of the previous extension request
+  @tracked previousExtensionStatus = null;
+
+  @service toast;
+  @service userState;
+
+  oldETA = new Date(this.args.task.endsOn * 1000).toLocaleString();
+
+  @use load = resource(({ on }) => {
+    const state = new TrackedMap();
+    const controller = new AbortController();
+
+    on.cleanup(() => controller.abort());
+    (async () => {
+      if (this.args.task) {
+        state.set('isLoading', true);
+        try {
+          const response = await fetch(
+            `${ENV.BASE_API_URL}/extension-requests/self/?taskId=${this.args.task.id}&dev=true`,
+            {
+              credentials: 'include',
+              signal: controller.signal,
+            }
+          );
+          if (response.status === 200) {
+            const data = await response.json();
+            if (!data.allExtensionRequests.length) {
+              throw Error(
+                'No extension request found for this task, want to create one?'
+              );
+            }
+            state.set('value', data.allExtensionRequests);
+            // Set the status of the previous extension request
+            this.previousExtensionStatus = data.allExtensionRequests[0].status;
+            state.set('isLoading', false);
+            return;
+          }
+          this.toast.error('Something went wrong!', '', {
+            ...toastNotificationTimeoutOptions,
+            timeOut: '3000',
+          });
+        } catch (error) {
+          state.set('error', error.message);
+          state.set('isLoading', false);
+          console.error(error);
+          this.toast.error(error.message, '', {
+            ...toastNotificationTimeoutOptions,
+            timeOut: '3000',
+          });
+        }
+      }
+    })();
+
+    return state;
+  });
+
+  get extensionData() {
+    const result = {};
+    result['isLoading'] = this.load.get('isLoading');
+    result['value'] = this.load.get('value');
+    result['error'] = this.load.get('error');
+    return result;
+  }
+
+  @action
+  createNewExtensionRequest() {
+    this.createExtensionRequest = true;
+  }
+
+  @action
+  closeForm() {
+    this.createExtensionRequest = false;
+  }
+
+  @action
+  async submitExtensionRequest(e) {
+    e.preventDefault();
+    this.disableExtensionRequestClose = true;
+    this.createExtensionRequestError = null;
+    //submit button
+    e.submitter.disabled = true;
+    const formData = new FormData(e.target);
+    const extensionTime = new Date(formData.get('newEndsOn')).getTime() / 1000;
+    const json = {};
+    formData.forEach(function (value, key) {
+      json[key] = value;
+    });
+
+    if (extensionTime < this.args.task.endsOn) {
+      this.toast.error(WARNING_INVALID_NEW_ETA, '', {
+        ...toastNotificationTimeoutOptions,
+        timeOut: '3000',
+      });
+      e.submitter.disabled = false;
+      this.disableExtensionRequestClose = false;
+      this.createExtensionRequestError =
+        'The newEndsOn value cannot be smaller than the oldEndsOn value';
+      return;
+    }
+    json['newEndsOn'] = extensionTime;
+    //setting default values
+    json['taskId'] = this.args.task.id;
+    json['assignee'] = this.userState.get('id');
+    json['oldEndsOn'] = this.args.task.endsOn;
+    json['status'] = 'PENDING';
+
+    try {
+      const response = await fetch(
+        `${ENV.BASE_API_URL}/extension-requests?dev=true`,
+        {
+          credentials: 'include',
+          method: 'POST',
+          body: JSON.stringify(json),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      );
+      const data = await response.json();
+      if (data.message === 'Extension Request created successfully!') {
+        this.disableExtensionRequestClose = false;
+        this.toast.success(data.message, '', {
+          ...toastNotificationTimeoutOptions,
+          timeOut: '3000',
+        });
+        setTimeout(this.args.closeModel, 2000);
+        return;
+      }
+      this.toast.error('Something went wrong!', '', {
+        ...toastNotificationTimeoutOptions,
+        timeOut: '3000',
+      });
+      e.submitter.disabled = false;
+    } catch (error) {
+      this.toast.error(error.message, '', {
+        ...toastNotificationTimeoutOptions,
+        timeOut: '3000',
+      });
+      setTimeout(this.args.closeModel, 2000);
+    }
+  }
+
+  @action
+  changeExtensionRequestETA(e) {
+    const extensionTime = new Date(e.target.value).getTime() / 1000;
+
+    if (extensionTime < this.args.task.endsOn) {
+      this.toast.error(WARNING_INVALID_NEW_ETA, '', {
+        ...toastNotificationTimeoutOptions,
+        timeOut: '3000',
+      });
+      e.target.value = '';
+      this.createExtensionRequestError =
+        'The newEndsOn value cannot be smaller than the oldEndsOn value';
+      return;
+    } else this.createExtensionRequestError = null;
+  }
+}

--- a/app/constants/user-status.js
+++ b/app/constants/user-status.js
@@ -11,6 +11,8 @@ export const USER_STATES = {
   ONBOARDING: 'ONBOARDING',
   DNE: 'DNE',
 };
+export const WARNING_INVALID_NEW_ETA =
+  'The newEndsOn value cannot be smaller than the oldEndsOn value';
 export const WARNING_FROM_DATE_EXCEEDS_UNTIL_DATE =
   'Until date cant lie before the From date. Please recheck the dates again.';
 export const THREE_DAYS_TIME_DIFFERENCE_MS = 172800000;

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -420,7 +420,7 @@
   padding: 18px;
   border-radius: 10px;
   background-color: var(--white);
-  overflow-y: scroll;
+  /* overflow-y: scroll; */
   position: absolute;
   left: 30%;
   right: 30%;
@@ -452,6 +452,7 @@
   justify-content: center;
   align-items: center;
   height: 100%;
+  width: 100%;
   flex-direction: column;
   margin: 10px 0px;
 }
@@ -479,7 +480,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  width: 80%;
+  width: 100%;
 }
 .extension-form__content form > label {
   font-weight: bold;
@@ -494,7 +495,9 @@
   color: var(--button-proceed--text);
   font-size: 1.2rem;
   border: none;
+  width: 100%;
   border-radius: 8px;
+  margin-top: 1rem;
   padding: 5px 9px;
 }
 
@@ -511,8 +514,8 @@
   margin: 5px 0px 15px 0px;
   padding: 5px;
   width: 100%;
-  border: none;
-  border-bottom: 1px solid var(--input-field-border);
+  border: 1px solid var(--input-field-border);
+  /* border-bottom: 1px solid var(--input-field-border); */
 }
 
 .extension-info__content > table,
@@ -581,4 +584,70 @@
     flex-direction: column;
     align-items: center;
   }
+}
+
+.extension-info__content table td {
+  white-space: normal;
+}
+
+.primary-button-style {
+  background-color: #008000;
+  color: var(--button-proceed--text);
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 8px;
+  padding: 5px 9px;
+  transition: background-color 0.3s ease;
+}
+.multiple-extension-form__open-button {
+  background-color: #008000;
+  color: var(--button-proceed--text);
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 8px;
+  padding: 5px 9px;
+  transition: background-color 0.3s ease;
+}
+
+.multiple-extension-form__create-button {
+  background-color: #008000;
+  color: var(--button-proceed--text);
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 8px;
+  padding: 5px 9px;
+  transition: background-color 0.3s ease;
+}
+
+.multiple-extension-form__open-button:hover {
+  background-color: #01ad01;
+  color: #fff;
+}
+
+.multiple-extension-form__create-button:hover {
+  background-color: #01ad01;
+  color: #fff;
+}
+
+.multiple-extension-form__container-close:hover{
+  background-color: #d50707;
+  color:#fff
+}
+
+.multiple-extension-form__container-close {
+  background-color:#a70606;
+  color: var(--button-proceed--text);
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 8px;
+  padding: 5px 9px;
+}
+.error-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.error-message {
+  color: red;
+  text-align: center;
 }

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -511,6 +511,8 @@
   border-radius: 8px;
   margin-top: 1rem;
   padding: 5px 9px;
+  display: flex;
+  align-items: center;
 }
 
 .extension-form__container-close:disabled {
@@ -622,14 +624,27 @@
 .error-message {
   color: red;
 }
+.error-container {
+  align-items: center;
+  height: 25px;
+  width: 100%; /* Initially, set the fixed height */ /* Initially, hide the container */
+}
+
+
+.error-placeholder {
+  color: red;
+  text-align: center;
+  visibility: hidden;
+}
+
 .multiple-extension-form__create-button[disabled] {
   cursor: not-allowed;
-  pointer-events: none;
+
+  background-color: #888;
 }
 
 .multiple-extension-form__create-button[disabled]:hover {
-  background-color: #0f120f;
-  color: var(--button-proceed--text);
+  background-color: #888;
 }
 
 
@@ -666,6 +681,10 @@
     text-align: right;
     width: 50%;
   }
+  /* .latest-extension-info__content{
+    width: 100%;
+    justify-content: center;
+  } */
 
   .latest-extension-info__content td {
     text-align: left;
@@ -686,4 +705,20 @@ textarea {
   width: 100%;
   height: 50%;
   overflow-y: auto;
+}
+
+div.buttons{
+  display: flex;
+  flex-direction:row;
+  min-width: 100%;
+  align-content: center;
+  justify-content: center;
+}
+
+.extension-reason{
+  display: flex;
+  margin: 0px !important;
+  justify-content: flex-end;
+  align-items: center;
+  min-width: 100%;
 }

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -683,10 +683,9 @@
   }
 
 .latest-extension-info__content th, td {
-  padding: 8px 8px;
+  padding: 8px 2px;
   vertical-align: top;
   min-width: 50%;
-  gap: 10px;
 }
 .latest-table{
   width: 100%;
@@ -700,7 +699,6 @@
 }
 tr>th,tr>td{
   vertical-align: top;
-  padding:2px;
 }
 
 textarea {

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -501,6 +501,18 @@
   padding: 5px 9px;
 }
 
+.multiple-extension-form__content form > button,
+.multiple-extension-form__container-close {
+  background-color: var(--button-proceed--bg);
+  color: var(--button-proceed--text);
+  font-size: 1.2rem;
+  border: none;
+  width: 40%;
+  border-radius: 8px;
+  margin-top: 1rem;
+  padding: 5px 9px;
+}
+
 .extension-form__container-close:disabled {
   opacity: 0.7;
   background-color: #888;
@@ -586,44 +598,42 @@
   }
 }
 
-.extension-info__content table td {
+.extension-info__content {
+  border-bottom: 1px solid var(--light-black);
+  margin: 10px;
+}
+.latest-extension-info__content table td {
   white-space: normal;
 }
 
-.primary-button-style {
-  background-color: #008000;
-  color: var(--button-proceed--text);
-  font-size: 1.2rem;
-  border: none;
-  border-radius: 8px;
-  padding: 5px 9px;
-  transition: background-color 0.3s ease;
+  .multiple-extension-form__container-close {
+    background-color:#a70606;
+    color: var(--button-proceed--text);
+    font-size: 1.2rem;
+    border: none;
+    border-radius: 8px;
+    padding: 5px 9px;
+    width: 40%;
+    display: flex;
+    justify-content: center;
+    margin:0 auto;
+  }
+
+.error-message {
+  color: red;
 }
-.multiple-extension-form__open-button {
-  background-color: #008000;
-  color: var(--button-proceed--text);
-  font-size: 1.2rem;
-  border: none;
-  border-radius: 8px;
-  padding: 5px 9px;
-  transition: background-color 0.3s ease;
+.multiple-extension-form__create-button[disabled] {
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
-.multiple-extension-form__create-button {
-  background-color: #008000;
+.multiple-extension-form__create-button[disabled]:hover {
+  background-color: #0f120f;
   color: var(--button-proceed--text);
-  font-size: 1.2rem;
-  border: none;
-  border-radius: 8px;
-  padding: 5px 9px;
-  transition: background-color 0.3s ease;
 }
 
-.multiple-extension-form__open-button:hover {
-  background-color: #01ad01;
-  color: #fff;
-}
 
+.multiple-extension-form__open-button:hover ,
 .multiple-extension-form__create-button:hover {
   background-color: #01ad01;
   color: #fff;
@@ -634,20 +644,46 @@
   color:#fff
 }
 
-.multiple-extension-form__container-close {
-  background-color:#a70606;
+.multiple-extension-form__create-button {
+  width: 60%;
+}
+
+.primary-button-style {
+  background-color: #008000;
   color: var(--button-proceed--text);
   font-size: 1.2rem;
+  width: 40%;
+  display: flex;
+  justify-content: center;
+  margin:0 auto;
   border: none;
   border-radius: 8px;
   padding: 5px 9px;
+  transition: background-color 0.3s ease;
 }
-.error-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+
+  .latest-extension-info__content th {
+    text-align: right;
+    width: 50%;
+  }
+
+  .latest-extension-info__content td {
+    text-align: left;
+    width: 50%;
+  }
+.latest-extension-info__content th,
+.latest-extension-info__content td {
+  
+  /* height: 50%;
+  width: 50%; */
+  /* overflow:hidden; */
+  box-sizing: border-box;
+  word-wrap: break-word;
+  padding: 5px;
+  max-width: 100%;
 }
-.error-message {
-  color: red;
-  text-align: center;
+textarea {
+  width: 100%;
+  height: 50%;
+  overflow-y: auto;
 }

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -468,7 +468,7 @@
 
 .extension-form__content-wrapper {
   width: 100%;
-  display: flex;
+  /* display: flex; */
   flex-direction: column;
   align-items: center;
   justify-content: center;
@@ -627,7 +627,7 @@
 .error-container {
   align-items: center;
   height: 25px;
-  width: 100%; /* Initially, set the fixed height */ /* Initially, hide the container */
+  width: 100%;
 }
 
 
@@ -681,26 +681,28 @@
     text-align: right;
     width: 50%;
   }
-  /* .latest-extension-info__content{
-    width: 100%;
-    justify-content: center;
-  } */
 
-  .latest-extension-info__content td {
-    text-align: left;
-    width: 50%;
-  }
-.latest-extension-info__content th,
-.latest-extension-info__content td {
-  
-  /* height: 50%;
-  width: 50%; */
-  /* overflow:hidden; */
-  box-sizing: border-box;
-  word-wrap: break-word;
-  padding: 5px;
-  max-width: 100%;
+.latest-extension-info__content th, td {
+  padding: 8px 8px;
+  vertical-align: top;
+  min-width: 50%;
+  gap: 10px;
 }
+.latest-table{
+  width: 100%;
+}
+.latest-extension-info__content th {
+  text-align: right;
+}
+.latest-extension-info__content td {
+  text-align: left;
+  word-wrap: normal;
+}
+tr>th,tr>td{
+  vertical-align: top;
+  padding:2px;
+}
+
 textarea {
   width: 100%;
   height: 50%;
@@ -713,12 +715,4 @@ div.buttons{
   min-width: 100%;
   align-content: center;
   justify-content: center;
-}
-
-.extension-reason{
-  display: flex;
-  margin: 0px !important;
-  justify-content: flex-end;
-  align-items: center;
-  min-width: 100%;
 }

--- a/tests/integration/components/tasks/multiple-extension-form-test.js
+++ b/tests/integration/components/tasks/multiple-extension-form-test.js
@@ -49,7 +49,7 @@ module('Integration | Component | Multiple Extension Form', function (hooks) {
   };
 
   test('When Clicked /"Close Form/" button or background task extension form should unmount', async function (assert) {
-    this.set('task', tasksData[0]);
+    this.set('task', tasksData[3]);
     this.set(
       'closeExtensionModel',
       closeExtensionModel(this.set, 'extensionFormOpened')
@@ -59,7 +59,6 @@ module('Integration | Component | Multiple Extension Form', function (hooks) {
       closeExtensionForm(this.set, 'extensionFormOpened')
     );
     this.set('extensionFormOpened', extensionFormOpened);
-
     await render(
       hbs`
       {{#if this.extensionFormOpened}}
@@ -71,22 +70,20 @@ module('Integration | Component | Multiple Extension Form', function (hooks) {
       />
       {{/if}}`
     );
+    await waitFor('[data-test-create-extension-button]');
     assert
-      .dom(this.element.querySelector('[data-test-title]'))
-      .hasText('Form for extension Request');
-    await click(
-      this.element.querySelector('[data-test-extension-form-container-close]')
-    );
-    assert.dom(this.element.querySelector('[data-test-title]')).doesNotExist();
+      .dom(this.element.querySelector('[data-test-create-extension-button]'))
+      .hasText('Request Extension');
 
-    extensionFormOpened = true;
-    this.set('extensionFormOpened', extensionFormOpened);
-    assert
-      .dom(this.element.querySelector('[data-test-title]'))
-      .hasText('Form for extension Request');
     await click(
-      this.element.querySelector('[data-test-extension-form-container-back]')
+      this.element.querySelector('[data-test-create-extension-button]')
     );
+    assert.dom('[data-test-extension-form-container-close]').exists();
+    const closeButton = this.element.querySelector(
+      '[data-test-extension-form-container-close]'
+    );
+    assert.ok(closeButton, 'Close button should exist');
+    await click(closeButton);
     assert.dom(this.element.querySelector('[data-test-title]')).doesNotExist();
   });
 
@@ -111,7 +108,7 @@ module('Integration | Component | Multiple Extension Form', function (hooks) {
     await waitFor('[data-test-create-extension-button]');
     assert
       .dom(this.element.querySelector('[data-test-create-extension-button]'))
-      .hasText('Create an extension request');
+      .hasText('Request Extension');
 
     await click(
       this.element.querySelector('[data-test-create-extension-button]')
@@ -195,7 +192,7 @@ module('Integration | Component | Multiple Extension Form', function (hooks) {
       hbs`<Task::ExtensionForm 
       @task={{this.task}} 
       @closeForm={{this.closeExtensionForm}} 
-      @title='Form for extension Request' 
+      @title='Extension Details' 
       @closeModel={{this.closeExtensionModel}}/>`
     );
     await waitFor('[data-test-create-extension-button]');
@@ -228,7 +225,7 @@ module('Integration | Component | Multiple Extension Form', function (hooks) {
       hbs`<Task::ExtensionForm 
       @task={{this.task}} 
       @closeForm={{this.closeExtensionForm}} 
-      @title='Form for extension Request' 
+      @title='Extension Details' 
       @closeModel={{this.closeExtensionModel}}/>`
     );
     await waitFor('[data-test-extension-info-content]');

--- a/tests/integration/components/tasks/multiple-extension-form-test.js
+++ b/tests/integration/components/tasks/multiple-extension-form-test.js
@@ -1,0 +1,323 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { tasks } from 'website-my/tests/fixtures/tasks';
+import { extensionRequests } from 'website-my/tests/fixtures/extension-requests';
+import { render, click, fillIn, waitFor, settled } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import makeServer from 'website-my/mirage/config';
+
+module('Integration | Component | Multiple Extension Form', function (hooks) {
+  setupRenderingTest(hooks);
+  let tasksData, extensionFormOpened, server;
+
+  hooks.after(function () {
+    server.shutdown();
+  });
+
+  hooks.before(function () {
+    tasksData = tasks;
+    extensionFormOpened = true;
+    server = makeServer({ environment: 'test' });
+    extensionRequests.forEach((obj) => {
+      server.create('extensionRequest', obj);
+    });
+  });
+
+  const toggleExtensionForm = (setter, name) => {
+    extensionFormOpened = !extensionFormOpened;
+    if (setter) {
+      setter(name, extensionFormOpened);
+    }
+  };
+
+  const closeExtensionForm = (setter, name) => () => {
+    extensionFormOpened = false;
+    if (setter) {
+      setter(name, false);
+    }
+  };
+
+  const closeExtensionModel = (setter, name) => (e) => {
+    if (!e) {
+      toggleExtensionForm(setter, name);
+      return;
+    }
+    e.stopPropagation();
+    if (e.target.classList.contains('extension-form__container-back')) {
+      toggleExtensionForm(setter, name);
+    }
+  };
+
+  test('When Clicked /"Close Form/" button or background task extension form should unmount', async function (assert) {
+    this.set('task', tasksData[0]);
+    this.set(
+      'closeExtensionModel',
+      closeExtensionModel(this.set, 'extensionFormOpened')
+    );
+    this.set(
+      'closeExtensionForm',
+      closeExtensionForm(this.set, 'extensionFormOpened')
+    );
+    this.set('extensionFormOpened', extensionFormOpened);
+
+    await render(
+      hbs`
+      {{#if this.extensionFormOpened}}
+      <Task::MultipleExtensionForm
+      @task={{this.task}}
+      @closeForm={{this.closeExtensionForm}}
+      @title='Form for extension Request'
+      @closeModel={{this.closeExtensionModel}}
+      />
+      {{/if}}`
+    );
+    assert
+      .dom(this.element.querySelector('[data-test-title]'))
+      .hasText('Form for extension Request');
+    await click(
+      this.element.querySelector('[data-test-extension-form-container-close]')
+    );
+    assert.dom(this.element.querySelector('[data-test-title]')).doesNotExist();
+
+    extensionFormOpened = true;
+    this.set('extensionFormOpened', extensionFormOpened);
+    assert
+      .dom(this.element.querySelector('[data-test-title]'))
+      .hasText('Form for extension Request');
+    await click(
+      this.element.querySelector('[data-test-extension-form-container-back]')
+    );
+    assert.dom(this.element.querySelector('[data-test-title]')).doesNotExist();
+  });
+
+  test('When no extension requests found, the option to create extension request should show and then later open form', async function (assert) {
+    this.set('task', tasksData[3]);
+    this.set(
+      'closeExtensionModel',
+      closeExtensionModel(this.set, 'extensionFormOpened')
+    );
+    this.set(
+      'closeExtensionForm',
+      closeExtensionForm(this.set, 'extensionFormOpened')
+    );
+
+    await render(
+      hbs`<Task::MultipleExtensionForm 
+      @task={{this.task}} 
+      @closeForm={{this.closeExtensionForm}} 
+      @title='Form for extension Request' 
+      @closeModel={{this.closeExtensionModel}}/>`
+    );
+    await waitFor('[data-test-create-extension-button]');
+    assert
+      .dom(this.element.querySelector('[data-test-create-extension-button]'))
+      .hasText('Create an extension request');
+
+    await click(
+      this.element.querySelector('[data-test-create-extension-button]')
+    );
+    assert
+      .dom(
+        this.element
+          .querySelector('[data-test-extension-from-content]')
+          .querySelector('button[type=submit]')
+      )
+      .exists();
+  });
+
+  test('When creating extension request, if the newEndsOn is smaller than the oldEndsOn then should throw error', async function (assert) {
+    this.set('task', tasksData[3]);
+    this.set(
+      'closeExtensionModel',
+      closeExtensionModel(this.set, 'extensionFormOpened')
+    );
+    this.set(
+      'closeExtensionForm',
+      closeExtensionForm(this.set, 'extensionFormOpened')
+    );
+
+    await render(
+      hbs`<Task::ExtensionForm 
+      @task={{this.task}} 
+      @closeForm={{this.closeExtensionForm}} 
+      @title='Form for extension Request' 
+      @closeModel={{this.closeExtensionModel}}/>`
+    );
+    await waitFor('[data-test-create-extension-button]');
+    assert
+      .dom(this.element.querySelector('[data-test-create-extension-button]'))
+      .hasText('Create an extension request');
+
+    await click(
+      this.element.querySelector('[data-test-create-extension-button]')
+    );
+    assert
+      .dom(
+        this.element
+          .querySelector('[data-test-extension-from-content]')
+          .querySelector('button[type=submit]')
+      )
+      .exists();
+
+    await fillIn(
+      '[data-test-extension-form-newEndsOn-input]',
+      '2021-09-09T09:45'
+    );
+    assert
+      .dom(this.element.querySelector('[data-test-extension-from-error]'))
+      .hasText(
+        'Error: The newEndsOn value cannot be smaller than the oldEndsOn value'
+      );
+
+    await settled();
+    // if filled valid time then remove the error
+    await fillIn(
+      '[data-test-extension-form-newEndsOn-input]',
+      '2024-09-09T09:45'
+    );
+    assert
+      .dom(this.element.querySelector('[data-test-extension-from-error]'))
+      .doesNotExist();
+  });
+
+  test('When no extension requests found, we should be able to create one', async function (assert) {
+    this.set('task', tasksData[3]);
+    this.set(
+      'closeExtensionModel',
+      closeExtensionModel(this.set, 'extensionFormOpened')
+    );
+    this.set(
+      'closeExtensionForm',
+      closeExtensionForm(this.set, 'extensionFormOpened')
+    );
+
+    await render(
+      hbs`<Task::ExtensionForm 
+      @task={{this.task}} 
+      @closeForm={{this.closeExtensionForm}} 
+      @title='Form for extension Request' 
+      @closeModel={{this.closeExtensionModel}}/>`
+    );
+    await waitFor('[data-test-create-extension-button]');
+    assert
+      .dom(this.element.querySelector('[data-test-create-extension-button]'))
+      .hasText('Create an extension request');
+
+    await click(
+      this.element.querySelector('[data-test-create-extension-button]')
+    );
+    assert
+      .dom(
+        this.element
+          .querySelector('[data-test-extension-from-content]')
+          .querySelector('button[type=submit]')
+      )
+      .exists();
+
+    //create extension request
+    await fillIn('[data-test-extension-form-reason-input]', 'Testing');
+    await fillIn(
+      '[data-test-extension-form-newEndsOn-input]',
+      '2030-12-31T02:43'
+    );
+    await fillIn('[data-test-extension-form-title-input]', 'TestingAgain');
+    await click(this.element.querySelector('button[type=submit]'));
+
+    // rendering the component again to check the new data
+    await render(
+      hbs`<Task::ExtensionForm 
+      @task={{this.task}} 
+      @closeForm={{this.closeExtensionForm}} 
+      @title='Form for extension Request' 
+      @closeModel={{this.closeExtensionModel}}/>`
+    );
+    await waitFor('[data-test-extension-info-content]');
+    assert
+      .dom(this.element.querySelector('[data-test-extension-info-content]'))
+      .containsText('Testing')
+      .containsText('TestingAgain')
+      .containsText('PENDING')
+      .containsText('1');
+  });
+
+  test('When previous extension request is approved, the button to create extension request should be there', async function (assert) {
+    let extensionRequestData = extensionRequests[0];
+    this.set('task', tasksData[0]);
+    this.set('previousExtensionStatus', extensionRequestData.status);
+    this.set(
+      'closeExtensionModel',
+      closeExtensionModel(this.set, 'extensionFormOpened')
+    );
+    this.set(
+      'closeExtensionForm',
+      closeExtensionForm(this.set, 'extensionFormOpened')
+    );
+
+    await render(
+      hbs`<Task::MultipleExtensionForm 
+      @task={{this.task}} 
+      @closeForm={{this.closeExtensionForm}} 
+      @title='Form for extension Request'
+      @closeModel={{this.closeExtensionModel}}/>
+      }`
+    );
+    await waitFor('[data-test-extension-info-content]');
+    assert
+      .dom(this.element.querySelector('[data-test-extension-info-content]'))
+      .containsText(extensionRequestData['title'])
+      .containsText(extensionRequestData['reason'])
+      .containsText(extensionRequestData['status']);
+    // Assert the initial state
+    if (['APPROVED', 'DENIED'].includes(this.previousExtensionStatus)) {
+      assert.dom('button[data-test-create-another-extension]').exists();
+
+      // Trigger the action to create a new extension request
+      await click('button[data-test-create-another-extension]');
+
+      assert
+        .dom(
+          this.element
+            .querySelector('[data-test-extension-from-content]')
+            .querySelector('button[type=submit]')
+        )
+        .exists();
+    } else {
+      assert.dom('[data-test-create-another-extension] button').doesNotExist();
+    }
+  });
+
+  test('When previous extension request is pending, the option to create extension request should show and then later open form', async function (assert) {
+    // Set up test data and conditions, such as setting this.previousExtensionStatus
+    let extensionRequestData = extensionRequests[1];
+    this.set('task', tasksData[0]);
+    this.set('previousExtensionStatus', extensionRequestData.status);
+
+    this.set(
+      'closeExtensionModel',
+      closeExtensionModel(this.set, 'extensionFormOpened')
+    );
+    this.set(
+      'closeExtensionForm',
+      closeExtensionForm(this.set, 'extensionFormOpened')
+    );
+
+    await render(
+      hbs`<Task::MultipleExtensionForm 
+        @task={{this.task}} 
+        @closeForm={{this.closeExtensionForm}} 
+        @title='Form for extension Request'
+        @closeModel={{this.closeExtensionModel}}/>`
+    );
+
+    await waitFor('[data-test-extension-info-content]');
+
+    // Assert the initial state
+    assert.dom('[data-test-extension-form-container]').doesNotExist(); // Replace with the actual selector for the component
+
+    // Trigger the action to create a new extension request
+    assert.dom('[data-test-create-another-extension] button').doesNotExist();
+
+    // Assert the resulting state after the action
+    assert.dom('[data-test-extension-form]').doesNotExist(); // Replace with the actual selector for the extension form
+  });
+});


### PR DESCRIPTION
**Changes Made:**
With this pull request, I have implemented dynamic button enabling for the "Create" button in accordance with the extension request status. The behavior is as follows:

**If no extension request exists previously:**
The "Create" button is now enabled, allowing users to initiate a new extension request.

**If there is a previous extension request:**
The "Create" button is enabled only if the status of the previous extension request is either "Approved" or "Denied."

Video for reference first that current behaviour is shown and after that with dev flag new behaviour is shown: 

[screen-capture (10).webm](https://github.com/Real-Dev-Squad/website-my/assets/37043221/5459605d-b358-40da-8e0b-ceb5bcf68397)


### Test Results & TestCoverage :
![image](https://github.com/Real-Dev-Squad/website-my/assets/37043221/e874d63f-ebd4-4716-8c10-03d01139e6b0)

![image](https://github.com/Real-Dev-Squad/website-my/assets/37043221/9b32525e-2f7e-4296-8bfb-2f3fcc7c174f)
![image](https://github.com/Real-Dev-Squad/website-my/assets/37043221/37c604f5-71a2-4a67-a5b5-8a9d72a235a2)