### PR TITLE
Adding UNASSIGNED and DONE to task status options

### DIFF
--- a/app/components/task/holder.hbs
+++ b/app/components/task/holder.hbs
@@ -32,12 +32,25 @@
         >
           {{#each this.availabletaskStatusList as |taskStatus|}}
             {{#if (not-eq taskStatus.key this.TASK_KEYS.ALL)}}
-              <option
-                value={{taskStatus.key}}
-                selected={{eq taskStatus.key this.status}}
-              >
-                {{taskStatus.displayLabel}}
-              </option>
+              {{#if @dev}}
+                  {{#if (not (or (eq taskStatus.key this.TASK_KEYS.AVAILABLE) (eq taskStatus.key this.TASK_KEYS.COMPLETED)))}}
+                    <option
+                      value={{taskStatus.key}}
+                      selected={{eq taskStatus.key this.status}}
+                    >
+                      {{taskStatus.displayLabel}}
+                    </option>
+                {{/if}}
+              {{else}}
+                  {{#if (not (or (eq taskStatus.key this.TASK_KEYS.UNASSIGNED) (eq taskStatus.key this.TASK_KEYS.DONE)))}}
+                    <option
+                      value={{taskStatus.key}}
+                      selected={{eq taskStatus.key this.status}}
+                    >
+                      {{taskStatus.displayLabel}}
+                    </option>
+                {{/if}}
+              {{/if}}
             {{/if}}
           {{/each}}
         </select>

--- a/app/constants/tasks.js
+++ b/app/constants/tasks.js
@@ -2,6 +2,7 @@ const TASK_KEYS = {
   ALL: 'ALL',
   AVAILABLE: 'AVAILABLE',
   ASSIGNED: 'ASSIGNED',
+  UNASSIGNED: 'UNASSIGNED',
   IN_PROGRESS: 'IN_PROGRESS',
   BLOCKED: 'BLOCKED',
   SMOKE_TESTING: 'SMOKE_TESTING',
@@ -14,16 +15,19 @@ const TASK_KEYS = {
   REGRESSION_CHECK: 'REGRESSION_CHECK',
   RELEASED: 'RELEASED',
   VERIFIED: 'VERIFIED',
+  DONE: 'DONE',
 };
 
 const {
   ALL,
   AVAILABLE,
   ASSIGNED,
+  UNASSIGNED,
   IN_PROGRESS,
   BLOCKED,
   SMOKE_TESTING,
   COMPLETED,
+  DONE,
   NEEDS_REVIEW,
   IN_REVIEW,
   APPROVED,
@@ -48,6 +52,10 @@ const TASK_STATUS_LIST = [
     key: ASSIGNED,
   },
   {
+    displayLabel: 'Unassigned',
+    key: UNASSIGNED,
+  },
+  {
     displayLabel: 'In Progress',
     key: IN_PROGRESS,
   },
@@ -62,6 +70,10 @@ const TASK_STATUS_LIST = [
   {
     displayLabel: 'Completed',
     key: COMPLETED,
+  },
+  {
+    displayLabel: 'Done',
+    key: DONE,
   },
   {
     displayLabel: 'Needs Review',
@@ -143,3 +155,6 @@ export const TASK_PERCENTAGE = {
 };
 
 export { TASK_KEYS, TASK_STATUS_LIST, TABS_TASK_STATUS_LIST };
+
+export const oldTaskStatus = { AVAILABLE: 'AVAILABLE', COMPLETED: 'COMPLETED' };
+export const newTaskStatus = { UNASSIGNED: 'UNASSIGNED', DONE: 'DONE' };

--- a/tests/integration/components/tasks/holder-test.js
+++ b/tests/integration/components/tasks/holder-test.js
@@ -1,7 +1,12 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { tasks, overDueTask } from 'website-my/tests/fixtures/tasks';
-import { TASK_KEYS, TASK_STATUS_LIST } from 'website-my/constants/tasks';
+import {
+  TASK_KEYS,
+  TASK_STATUS_LIST,
+  oldTaskStatus,
+  newTaskStatus,
+} from 'website-my/constants/tasks';
 import { find, render, waitUntil, fillIn, select } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
@@ -239,6 +244,141 @@ module('Integration | Component | Tasks Holder', function (hooks) {
       .hasValue(TASK_KEYS.IN_PROGRESS);
 
     await select('[data-test-task-status-select]', TASK_KEYS.VERIFIED);
+
+    assert.equal(onTaskUpdateCalled, 1, 'onTaskUpdate should be called once');
+  });
+
+  test('Check if UNASSIGNED and DONE is not in task status options when dev is false', async function (assert) {
+    this.set('task', tasksData[3]);
+    this.set('mock', () => {});
+    this.set('isLoading', false);
+    this.set('disabled', false);
+    this.set('defaultType', DEFAULT_TASK_TYPE);
+
+    await render(hbs`<Task::Holder
+    @task={{this.task}} 
+    @onTaskChange={{this.mock}} 
+    @onStausChange={{this.mock}} 
+    @onTaskUpdate={{this.mock}} 
+    @isLoading={{this.isLoading}} 
+    @userSelectedTask={{this.defaultType}} 
+    @disabled={{this.disabled}}
+  />`);
+
+    await waitUntil(() => find('[data-test-task-status-select]'));
+
+    const taskStatusList = this.element.querySelector(
+      '[data-test-task-status-select]'
+    );
+
+    const updatedTaskKeys = Object.keys(TASK_KEYS).filter(
+      (key) => !(key in newTaskStatus)
+    );
+
+    for (let i = 0; i < taskStatusList.options.length; i++) {
+      const optionValue = taskStatusList.options[i].value;
+      assert.ok(updatedTaskKeys.includes(optionValue));
+    }
+  });
+
+  test('Check if UNASSIGNED and DONE is in task status options when dev is true', async function (assert) {
+    this.set('task', tasksData[3]);
+    this.set('mock', () => {});
+    this.set('isLoading', false);
+    this.set('disabled', false);
+    this.set('defaultType', DEFAULT_TASK_TYPE);
+
+    await render(hbs`<Task::Holder
+    @task={{this.task}} 
+    @onTaskChange={{this.mock}} 
+    @onStausChange={{this.mock}} 
+    @onTaskUpdate={{this.mock}} 
+    @isLoading={{this.isLoading}} 
+    @userSelectedTask={{this.defaultType}} 
+    @disabled={{this.disabled}}
+    @dev={{true}}
+  />`);
+
+    await waitUntil(() => find('[data-test-task-status-select]'));
+
+    const taskStatusList = this.element.querySelector(
+      '[data-test-task-status-select]'
+    );
+
+    const updatedTaskKeys = Object.keys(TASK_KEYS).filter(
+      (key) => !(key in oldTaskStatus)
+    );
+
+    for (let i = 0; i < taskStatusList.options.length; i++) {
+      const optionValue = taskStatusList.options[i].value;
+      assert.ok(updatedTaskKeys.includes(optionValue));
+    }
+  });
+
+  test('Verify task status update to UNASSIGNED when dev is true', async function (assert) {
+    const testTask = tasksData[3];
+
+    testTask.status = TASK_KEYS.IN_PROGRESS;
+
+    let onTaskUpdateCalled = 0;
+
+    this.set('task', testTask);
+    this.set('onTaskUpdate', () => {
+      onTaskUpdateCalled++;
+    });
+    this.set('mock', () => {});
+    this.set('isLoading', false);
+    this.set('disabled', false);
+    this.set('defaultType', DEFAULT_TASK_TYPE);
+
+    await render(hbs`<Task::Holder
+    @task={{this.task}}
+    @onTaskUpdate={{onTaskUpdate}}
+    @onTaskChange={{this.mock}}
+    @userSelectedTask={{this.defaultType}}
+    @disabled={{this.disabled}}
+    @dev={{true}}
+  />`);
+
+    assert
+      .dom('[data-test-task-status-select]')
+      .hasValue(TASK_KEYS.IN_PROGRESS);
+
+    await select('[data-test-task-status-select]', TASK_KEYS.UNASSIGNED);
+
+    assert.equal(onTaskUpdateCalled, 1, 'onTaskUpdate should be called once');
+  });
+
+  test('Verify task status update to DONE when dev is true', async function (assert) {
+    const testTask = tasksData[3];
+
+    testTask.status = TASK_KEYS.IN_PROGRESS;
+
+    let onTaskUpdateCalled = 0;
+
+    this.set('task', testTask);
+    this.set('onTaskUpdate', () => {
+      onTaskUpdateCalled++;
+    });
+    this.set('mock', () => {});
+    this.set('isLoading', false);
+    this.set('disabled', false);
+    this.set('defaultType', DEFAULT_TASK_TYPE);
+
+    await render(hbs`<Task::Holder
+    @task={{this.task}}
+    @onTaskUpdate={{onTaskUpdate}}
+    @onTaskChange={{this.mock}}
+    @userSelectedTask={{this.defaultType}}
+    @disabled={{this.disabled}}
+    @dev={{true}}
+  />`);
+
+    assert
+      .dom('[data-test-task-status-select]')
+      .hasValue(TASK_KEYS.IN_PROGRESS);
+
+    await select('[data-test-task-status-select]', TASK_KEYS.DONE);
 
     assert.equal(onTaskUpdateCalled, 1, 'onTaskUpdate should be called once');
   });


### PR DESCRIPTION
### Issue: #468 

### Description:
We are migrating our task status from `AVAILABLE` to `UNASSIGNED`, `COMPLETED` to `DONE`.
Changes are made to reflect the above under feature flag.

When dev is false we would have `AVAILABLE` and `COMPLETED` in task status options.
When dev is true we would have `COMPLETED` and `DONE` in task status options.

### Before changes:
<img width="960" alt="image" src="https://github.com/Real-Dev-Squad/website-my/assets/77037622/61da1b0d-2b14-4d5a-8e24-3408459b22e8">

### After changes:
<img width="960" alt="image" src="https://github.com/Real-Dev-Squad/website-my/assets/77037622/83a1e347-9403-4132-820b-fb48e8c874d6">
