### PR TITLE
cancel OOO button enabled

### DIFF
--- a/app/components/user-status.hbs
+++ b/app/components/user-status.hbs
@@ -4,34 +4,46 @@
   </div>
 {{else}}
 <div class="heading">
-  {{#each this.currentUserStatus as |currentStatus|}}
-  {{#if (eq @status currentStatus.status)}}
+    {{#each this.currentUserStatus as |currentStatus|}}
+      {{#if (eq @status currentStatus.status)}}
     {{#if (eq currentStatus.status "ONBOARDING")}}
       <div data-test-onboarding-details class="onboarding-details">
-        <h2 data-test-status>You are undergoing onboarding</h2>
-        <p data-test-details>
-          If you are a Developer, please complete your submission for 
+            <h2 data-test-status>You are undergoing onboarding</h2>
+            <p data-test-details>
+              If you are a Developer, please complete your submission for
           <a href="https://github.com/Real-Dev-Squad/lift-simulation">Lift Simulation</a>, 
           and ask for doubts in the team chat on Discord.
-        </p>
+            </p>
         <p data-test-details>If you are not a developer, please contact Ankush for next steps.</p>
-      </div>
-    {{else}}
-    <h2 data-test-status>{{currentStatus.message}}</h2>
-    {{/if}}
-  {{/if}}
-  {{/each}}
-</div>
+          </div>
+        {{else}}
+          <h2 data-test-status>{{currentStatus.message}}</h2>
+        {{/if}}
+      {{/if}}
+    {{/each}}
+  </div>
 
 <div class="buttons">
-  {{#each this.currentUserStatus as |currentStatus|}}
-    {{#if (eq @status currentStatus.status)}}
-      {{#each currentStatus.otherAvailableStatus as |otherPossibleStatus|}}
-        <button data-test-update-status-OOO class={{otherPossibleStatus.class}} type="button" disabled={{@isStatusUpdating}} {{on "click" (fn this.changeStatus otherPossibleStatus.status )}}>
-          <span>{{otherPossibleStatus.message}}</span>
-        </button>
-      {{/each}}
-    {{/if}}
-  {{/each}}
-</div>
+    {{#each this.currentUserStatus as |currentStatus|}}
+      {{#if (eq @status currentStatus.status)}}
+        {{#if (eq currentStatus.status "OOO")}}
+          <button
+            data-test-cancel-status-OOO
+            class='buttons__cancel--ooo'
+            type='button'
+            disabled={{@isStatusUpdating}}
+            {{on 'click' (fn this.cancelOOOStatus currentStatus.status)}}
+          >
+            <span>Cancel OOO</span>
+          </button>
+          {{else}}
+            {{#each currentStatus.otherAvailableStatus as |otherPossibleStatus|}}
+          <button data-test-update-status-OOO class={{otherPossibleStatus.class}} type="button" disabled={{@isStatusUpdating}} {{on "click" (fn this.changeStatus otherPossibleStatus.status )}}>
+                <span>{{otherPossibleStatus.message}}</span>
+              </button>
+            {{/each}}
+        {{/if}}
+      {{/if}}
+    {{/each}}
+  </div>
 {{/if}}

--- a/app/components/user-status.hbs
+++ b/app/components/user-status.hbs
@@ -27,15 +27,17 @@
     {{#each this.currentUserStatus as |currentStatus|}}
       {{#if (eq @status currentStatus.status)}}
         {{#if (eq currentStatus.status "OOO")}}
-          <button
-            data-test-cancel-status-OOO
-            class='buttons__cancel--ooo'
-            type='button'
-            disabled={{@isStatusUpdating}}
-            {{on 'click' (fn this.cancelOOOStatus currentStatus.status)}}
-          >
-            <span>Cancel OOO</span>
-          </button>
+          {{#if this.isDevMode}}
+            <button
+              data-test-cancel-status-OOO
+              class='buttons__cancel--ooo'
+              type='button'
+              disabled={{@isStatusUpdating}}
+              {{on 'click' (fn this.cancelOOOStatus currentStatus.status)}}
+            >
+              <span>Cancel OOO</span>
+            </button>
+          {{/if}}
           {{else}}
             {{#each currentStatus.otherAvailableStatus as |otherPossibleStatus|}}
           <button data-test-update-status-OOO class={{otherPossibleStatus.class}} type="button" disabled={{@isStatusUpdating}} {{on "click" (fn this.changeStatus otherPossibleStatus.status )}}>

--- a/app/components/user-status.hbs
+++ b/app/components/user-status.hbs
@@ -27,7 +27,7 @@
     {{#each this.currentUserStatus as |currentStatus|}}
       {{#if (eq @status currentStatus.status)}}
         {{#if (eq currentStatus.status "OOO")}}
-          {{#if this.isDevMode}}
+          {{#if @dev}}
             <button
               data-test-cancel-status-OOO
               class='buttons__cancel--ooo'

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -1,14 +1,8 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
-import { inject as service } from '@ember/service';
 import { USER_STATES } from '../constants/user-status';
 import { getUTCMidnightTimestampFromDate } from '../utils/date-conversion';
 export default class UserStatusComponent extends Component {
-  @service featureFlag;
-
-  get isDevMode() {
-    return this.featureFlag.isDevMode;
-  }
 
   ALL_FEASIBLE_STATUS = {
     [USER_STATES.ACTIVE]: {

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -1,8 +1,15 @@
 import Component from '@glimmer/component';
 import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 import { USER_STATES } from '../constants/user-status';
 import { getUTCMidnightTimestampFromDate } from '../utils/date-conversion';
 export default class UserStatusComponent extends Component {
+  @service featureFlag;
+
+  get isDevMode() {
+    return this.featureFlag.isDevMode;
+  }
+
   ALL_FEASIBLE_STATUS = {
     [USER_STATES.ACTIVE]: {
       status: USER_STATES.ACTIVE,

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -64,4 +64,10 @@ export default class UserStatusComponent extends Component {
       this.args.changeStatus(status);
     }
   }
+
+  @action async cancelOOOStatus(status) {
+    if (status === USER_STATES.OOO) {
+      await this.args.updateStatus({ cancelOoo: true });
+    }
+  }
 }

--- a/app/components/user-status.js
+++ b/app/components/user-status.js
@@ -3,7 +3,6 @@ import { action } from '@ember/object';
 import { USER_STATES } from '../constants/user-status';
 import { getUTCMidnightTimestampFromDate } from '../utils/date-conversion';
 export default class UserStatusComponent extends Component {
-
   ALL_FEASIBLE_STATUS = {
     [USER_STATES.ACTIVE]: {
       status: USER_STATES.ACTIVE,

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -10,10 +10,15 @@ const BASE_URL = ENV.BASE_API_URL;
 
 export default class IndexController extends Controller {
   @service toast;
+  @service featureFlag;
   @tracked status = this.model;
   @tracked isStatusUpdating = false;
   @tracked showUserStateModal = false;
   @tracked newStatus;
+
+  get isDevMode() {
+    return this.featureFlag.isDevMode;
+  }
 
   @action toggleUserStateModal() {
     this.showUserStateModal = !this.showUserStateModal;

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -21,11 +21,11 @@ export default class IndexController extends Controller {
 
   @action async updateStatus(newStatus) {
     this.isStatusUpdating = true;
-    if(!("cancelOoo" in newStatus)){
+    if (!('cancelOoo' in newStatus)) {
       if (newStatus.currentStatus.state !== USER_STATES.ACTIVE) {
         this.toggleUserStateModal();
       }
-    }  
+    }
     try {
       await fetch(`${BASE_URL}/users/status/self?userStatusFlag=true`, {
         method: 'PATCH',

--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -21,9 +21,11 @@ export default class IndexController extends Controller {
 
   @action async updateStatus(newStatus) {
     this.isStatusUpdating = true;
-    if (newStatus.currentStatus.state !== USER_STATES.ACTIVE) {
-      this.toggleUserStateModal();
-    }
+    if(!("cancelOoo" in newStatus)){
+      if (newStatus.currentStatus.state !== USER_STATES.ACTIVE) {
+        this.toggleUserStateModal();
+      }
+    }  
     try {
       await fetch(`${BASE_URL}/users/status/self?userStatusFlag=true`, {
         method: 'PATCH',

--- a/app/styles/user-status.css
+++ b/app/styles/user-status.css
@@ -77,6 +77,19 @@
   width: 25rem;
 }
 
+.buttons__cancel--ooo {
+  font-size: 1.25rem;
+  color: var(--button--color--text);
+  font-weight: 700;
+  border: 3px solid var(--button--color--border);
+  padding: 20px;
+  margin-bottom: 40px;
+  border-radius: 10px;
+  background: var( --button--color--bg);
+  cursor: pointer;
+  width: 15rem;
+}
+
 .buttons__ooo:hover {
   color: var(--button--ooo--bg);
   background: var(--button--ooo--text);

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,12 +1,22 @@
 <div class="greeting">
   <h1>Welcome to my site!</h1>
 </div>
-<UserStatus 
-  @status={{this.status}} 
-  @changeStatus={{this.changeStatus}} 
-  @isStatusUpdating={{this.isStatusUpdating}}
-  @updateStatus={{this.updateStatus}}
-/>
+{{#if this.isDevMode}}
+  <UserStatus 
+    @status={{this.status}} 
+    @changeStatus={{this.changeStatus}}
+    @dev={{this.isDevMode}} 
+    @isStatusUpdating={{this.isStatusUpdating}}
+    @updateStatus={{this.updateStatus}}
+  />
+  {{else}}
+  <UserStatus 
+    @status={{this.status}} 
+    @changeStatus={{this.changeStatus}} 
+    @isStatusUpdating={{this.isStatusUpdating}}
+    @updateStatus={{this.updateStatus}}
+  />
+{{/if}}
 <UserStatusModal
   @isStatusUpdating={{this.isStatusUpdating}}
   @newStatus={{this.newStatus}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,22 +1,13 @@
 <div class="greeting">
   <h1>Welcome to my site!</h1>
 </div>
-{{#if this.isDevMode}}
-  <UserStatus 
-    @status={{this.status}} 
-    @changeStatus={{this.changeStatus}}
-    @dev={{this.isDevMode}} 
-    @isStatusUpdating={{this.isStatusUpdating}}
-    @updateStatus={{this.updateStatus}}
-  />
-  {{else}}
-  <UserStatus 
-    @status={{this.status}} 
-    @changeStatus={{this.changeStatus}} 
-    @isStatusUpdating={{this.isStatusUpdating}}
-    @updateStatus={{this.updateStatus}}
-  />
-{{/if}}
+<UserStatus 
+  @status={{this.status}} 
+  @changeStatus={{this.changeStatus}}
+  @dev={{this.isDevMode}} 
+  @isStatusUpdating={{this.isStatusUpdating}}
+  @updateStatus={{this.updateStatus}}
+/>
 <UserStatusModal
   @isStatusUpdating={{this.isStatusUpdating}}
   @newStatus={{this.newStatus}}

--- a/tests/integration/components/user-status-test.js
+++ b/tests/integration/components/user-status-test.js
@@ -76,14 +76,14 @@ module('Integration | Component | user-status', function (hooks) {
       isStatusUpdating: false,
       changeStatus: () => {},
       updateStatus: () => {},
-      dev:true
+      dev: true,
     });
 
     await render(hbs`
         <UserStatus 
           @status={{this.status}} 
           @changeStatus={{this.changeStatus}} 
-          @dev={{this.isDevMode}} 
+          @dev={{this.dev}} 
           @isStatusUpdating={{this.isStatusUpdating}}
           @updateStatus={{this.updateStatus}}
         />
@@ -103,6 +103,7 @@ module('Integration | Component | user-status', function (hooks) {
         const { cancelOoo } = cancelOOOPayload;
         assert.equal(cancelOoo, true, 'cancel OOO status');
       },
+      dev: true,
     });
 
     await render(hbs`
@@ -110,6 +111,7 @@ module('Integration | Component | user-status', function (hooks) {
           @status={{this.status}} 
           @changeStatus={{this.changeStatus}} 
           @isStatusUpdating={{this.isStatusUpdating}}
+          @dev={{this.dev}} 
           @updateStatus={{this.updateStatus}}
         />
     `);

--- a/tests/integration/components/user-status-test.js
+++ b/tests/integration/components/user-status-test.js
@@ -68,6 +68,7 @@ module('Integration | Component | user-status', function (hooks) {
     `);
 
     assert.dom('[data-test-status]').hasText(`You are OOO`);
+    assert.dom('[data-test-cancel-status-OOO]').hasProperty('button');
     assert.dom('[data-test-cancel-status-OOO]').hasText('Cancel OOO');
   });
 

--- a/tests/integration/components/user-status-test.js
+++ b/tests/integration/components/user-status-test.js
@@ -50,7 +50,7 @@ module('Integration | Component | user-status', function (hooks) {
       .hasText('Change your status to OOO');
   });
 
-  test('show relevant data when status is OOO', async function (assert) {
+  test('show relevant data when status is OOO and dev is false', async function (assert) {
     this.setProperties({
       status: 'OOO',
       isStatusUpdating: false,
@@ -68,8 +68,30 @@ module('Integration | Component | user-status', function (hooks) {
     `);
 
     assert.dom('[data-test-status]').hasText(`You are OOO`);
-    assert.dom('[data-test-cancel-status-OOO]').hasProperty('button');
-    assert.dom('[data-test-cancel-status-OOO]').hasText('Cancel OOO');
+  });
+
+  test('show relevant data when status is OOO and dev is true', async function (assert) {
+    this.setProperties({
+      status: 'OOO',
+      isStatusUpdating: false,
+      changeStatus: () => {},
+      updateStatus: () => {},
+      dev:true
+    });
+
+    await render(hbs`
+        <UserStatus 
+          @status={{this.status}} 
+          @changeStatus={{this.changeStatus}} 
+          @dev={{this.isDevMode}} 
+          @isStatusUpdating={{this.isStatusUpdating}}
+          @updateStatus={{this.updateStatus}}
+        />
+    `);
+
+    assert.dom('[data-test-status]').hasText(`You are OOO`);
+    assert.dom('[ data-test-cancel-status-OOO]').hasProperty('button');
+    assert.dom('[ data-test-cancel-status-OOO]').hasText('Cancel OOO');
   });
 
   test('payload contains relevant data when status is changed from OOO to IDLE or ACTIVE', async function (assert) {

--- a/tests/integration/components/user-status-test.js
+++ b/tests/integration/components/user-status-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { click, render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 
 module('Integration | Component | user-status', function (hooks) {
@@ -68,9 +68,7 @@ module('Integration | Component | user-status', function (hooks) {
     `);
 
     assert.dom('[data-test-status]').hasText(`You are OOO`);
-    assert
-      .dom('[data-test-cancel-status-OOO]')
-      .hasText('Cancel OOO');
+    assert.dom('[data-test-cancel-status-OOO]').hasText('Cancel OOO');
   });
 
   test('payload contains relevant data when status is changed from OOO to IDLE or ACTIVE', async function (assert) {
@@ -79,8 +77,8 @@ module('Integration | Component | user-status', function (hooks) {
       isStatusUpdating: false,
       changeStatus: () => {},
       updateStatus: (cancelOOOPayload) => {
-        const {cancelOoo} = cancelOOOPayload
-        assert.equal(cancelOoo, true, 'cancel OOO status')
+        const { cancelOoo } = cancelOOOPayload;
+        assert.equal(cancelOoo, true, 'cancel OOO status');
       },
     });
 
@@ -95,5 +93,4 @@ module('Integration | Component | user-status', function (hooks) {
 
     await click('.buttons__cancel--ooo');
   });
-
 });

--- a/tests/integration/components/user-status-test.js
+++ b/tests/integration/components/user-status-test.js
@@ -50,18 +50,20 @@ module('Integration | Component | user-status', function (hooks) {
       .hasText('Change your status to OOO');
   });
 
-  test('show relevant data when status is OOO and dev is false', async function (assert) {
+  test('show relevant data when status is OOO and not have feature flag', async function (assert) {
     this.setProperties({
       status: 'OOO',
       isStatusUpdating: false,
       changeStatus: () => {},
       updateStatus: () => {},
+      dev: false,
     });
 
     await render(hbs`
         <UserStatus 
           @status={{this.status}} 
-          @changeStatus={{this.changeStatus}} 
+          @changeStatus={{this.changeStatus}}
+          @dev={{this.dev}}  
           @isStatusUpdating={{this.isStatusUpdating}}
           @updateStatus={{this.updateStatus}}
         />
@@ -70,7 +72,7 @@ module('Integration | Component | user-status', function (hooks) {
     assert.dom('[data-test-status]').hasText(`You are OOO`);
   });
 
-  test('show relevant data when status is OOO and dev is true', async function (assert) {
+  test('show relevant data when status is OOO and have feature flag', async function (assert) {
     this.setProperties({
       status: 'OOO',
       isStatusUpdating: false,

--- a/tests/integration/components/user-status-test.js
+++ b/tests/integration/components/user-status-test.js
@@ -68,5 +68,32 @@ module('Integration | Component | user-status', function (hooks) {
     `);
 
     assert.dom('[data-test-status]').hasText(`You are OOO`);
+    assert
+      .dom('[data-test-cancel-status-OOO]')
+      .hasText('Cancel OOO');
   });
+
+  test('payload contains relevant data when status is changed from OOO to IDLE or ACTIVE', async function (assert) {
+    this.setProperties({
+      status: 'OOO',
+      isStatusUpdating: false,
+      changeStatus: () => {},
+      updateStatus: (cancelOOOPayload) => {
+        const {cancelOoo} = cancelOOOPayload
+        assert.equal(cancelOoo, true, 'cancel OOO status')
+      },
+    });
+
+    await render(hbs`
+        <UserStatus 
+          @status={{this.status}} 
+          @changeStatus={{this.changeStatus}} 
+          @isStatusUpdating={{this.isStatusUpdating}}
+          @updateStatus={{this.updateStatus}}
+        />
+    `);
+
+    await click('.buttons__cancel--ooo');
+  });
+
 });


### PR DESCRIPTION
### Issue Closes https://github.com/Real-Dev-Squad/website-my/issues/495

### What is the change?

-  Added a **cancel OOO** button when user status is OOO so that the user can return to work before the designated
   out-of-office period concludes.
- A helper function which gets triggered once the user clicks the **cancel OOO**  button. 
- A PATCH request is made to **/users/status/self** with a request payload containing an object **{  cancelOoo: true }**
-  added an if condition in the controller so that the _UserStatusModal_  doesnot pop up when user clicks on cancel OOO button
- Written tests for the cancel OOO button and the required payload.
- feature under feature flag

### Is Development Tested?

- [x] Yes
- [ ] No

### Before & After Change Screenshots

[screen-capture.webm](https://github.com/Real-Dev-Squad/website-my/assets/68290209/0a49df09-9b5d-4d8a-8271-5b8cac038451)


### Test

![Screenshot 2023-10-13 185955](https://github.com/Real-Dev-Squad/website-my/assets/68290209/cb4f2b44-c30e-4454-bd05-f590bf29e7d7)





