### PR TITLE
Fixed timestamp issue in review statement

### DIFF
--- a/app/components/task/multiple-extension-form.hbs
+++ b/app/components/task/multiple-extension-form.hbs
@@ -80,7 +80,10 @@
                   }}approved{{else}}denied{{/if}}
                   by
                   {{extension.reviewedBy}}
-                  {{convertDate (array extension.timestamp) end_date=0}}.
+                  {{#if extension.reviewedAt}}{{convertDate
+                      (array extension.reviewedAt)
+                      end_date=0
+                    }}{{/if}}
                 </p>
               {{/if}}
             {{/each}}

--- a/tests/fixtures/extension-requests.js
+++ b/tests/fixtures/extension-requests.js
@@ -10,6 +10,7 @@ const extensionRequests = [
     timestamp: 1673784012,
     assignee: 'ivinayakg',
     reviewedBy: 'Joy Gupta',
+    reviewedAt: 1698555808,
   },
   {
     oldEndsOn: 57658796,


### PR DESCRIPTION
### Developer Name: Joy Gupta

### Purpose
Reviewed log should show the timestamp when the request was reviewed and not when it was created
### PR Number(s): 511

### Issue Ticket
- https://github.com/Real-Dev-Squad/website-my/issues/486

### Proposal Doc
https://docs.google.com/document/d/1sf-BAs7C6wmfjRVS-82X492hcb_7jAfIM-7pWtizuXE/edit

### Frontend Changes
- [x] Yes
- [ ] No

### Is Under Feature Flag
- [x] Yes
- [ ] No

### Database changes: 
- [ ] Yes
- [x] No

### Breaking changes (If your feature is breaking/missing something please mention pending tickets): 
- [ ] Yes
- [x] No

### Deployment notes:
NA

### Tested in local
- [x] Yes
- [ ] No

### List of PRs going in this Sync
- https://github.com/Real-Dev-Squad/website-backend/pull/1635

### QA Instructions, Screenshots, Recordings

Run `yarn test:ember` and there you can see test case running.
<img width="350" alt="Screenshot 2023-10-29 at 11 45 23" src="https://github.com/Real-Dev-Squad/website-my/assets/56365512/8d9323e7-bbac-4cf5-9324-c4cce1461f98">


### Working Proof
This extension request was made 1 week ago and was approved few hours ago

Before:
<img width="621" alt="Screenshot 2023-10-29 at 11 39 57" src="https://github.com/Real-Dev-Squad/website-my/assets/56365512/66827925-40bc-4572-b25c-590fcb921261">

After: 
<img width="621" alt="Screenshot 2023-10-29 at 11 40 17" src="https://github.com/Real-Dev-Squad/website-my/assets/56365512/e4753b26-84e0-447b-8300-5713bfc59ae2">




