### PR TITLE
fix: extension request form height issue

### DIFF
--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -442,7 +442,6 @@
   position: absolute;
   left: 30%;
   right: 30%;
-  height: max-content;
   gap: 20px;
   display: flex;
   flex-direction: column;
@@ -558,8 +557,8 @@
 }
 
 .extension-info__content {
-  border-bottom: 1px solid var(--light-black);
-  margin: 10px;
+  border-bottom: 4px solid var(--light-black);
+  margin: 90px;
 }
 
 .task-details__status-site-link {

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -557,8 +557,8 @@
 }
 
 .extension-info__content {
-  border-bottom: 4px solid var(--light-black);
-  margin: 90px;
+  border-bottom: 1px solid var(--light-black);
+  margin: 10px;
 }
 
 .task-details__status-site-link {

--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -734,6 +734,8 @@ div.buttons {
   min-width: 100%;
   align-content: center;
   justify-content: center;
+  align-items: stretch;
+  gap: 10px;
 }
 .hidden {
   display: none;


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 17/03/2024
<!--Developer Name Here-->
Developer Name: Kaustubh

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
[#580
](https://github.com/Real-Dev-Squad/website-my/issues/580)

## Description
The property height:max-content on the `extension-form__container-main` class was causing issues in safari, mainly it caused the inner `extension-form__content` class to have height 0, which in turn caused the parent div (the white background modal) to have smaller height since some part of its content(the div with class `extension-form__content`) had effectively height zero.
Here max-content isn't really needed, as the div automatically adjusts its height depending on the height of its children.

[Issue with max-content in Safari](https://discussions.apple.com/thread/252928862?sortBy=best )
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Before</summary>

<!-- Attach your screenshots here👇-->
The max-content property was not getting honoured in safari browser.
</details>
<img width="599" alt="Screenshot 2024-03-17 at 4 36 27 AM" src="https://github.com/Real-Dev-Squad/website-my/assets/94971261/96437066-fe99-4530-add2-da74f3dc3719">
<img width="595" alt="Screenshot 2024-03-17 at 5 15 37 PM" src="https://github.com/Real-Dev-Squad/website-my/assets/94971261/449dc065-77d0-4709-be0c-b4ab9b932d8f">



<summary>After</summary>
<img width="506" alt="Screenshot 2024-03-17 at 5 09 57 PM" src="https://github.com/Real-Dev-Squad/website-my/assets/94971261/aacdcc96-9f82-4050-a094-9fec5a86fdd5">
<!--Attach or link to relevant screenshots or visual aids-->
<img width="597" alt="Screenshot 2024-03-17 at 5 13 48 PM" src="https://github.com/Real-Dev-Squad/website-my/assets/94971261/312ef1e5-4e5d-46f3-aac1-df114ad025c3">
## Test Coverage

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
