### PR TITLE
Refactor : Updated API for verifying external-account (#588)

### DIFF
--- a/app/controllers/discord.js
+++ b/app/controllers/discord.js
@@ -6,6 +6,7 @@ import { tracked } from '@glimmer/tracking';
 import { action } from '@ember/object';
 
 export default class DiscordController extends Controller {
+  @service router;
   @service toast;
   @tracked discordId =
     this.model.externalAccountData.attributes.discordId || '';
@@ -13,6 +14,15 @@ export default class DiscordController extends Controller {
   @tracked isLinking = false;
   @tracked consent = false;
 
+  @tracked token = '';
+
+  queryParams = {
+    token: { refreshModel: true },
+  };
+
+  async model() {
+    this.token = this.paramsFor('discord').token;
+  }
   @action setConsent() {
     this.consent = !this.consent;
   }
@@ -22,14 +32,16 @@ export default class DiscordController extends Controller {
       this.isLinking = true;
 
       if (this.consent) {
-        const response = await fetch(`${ENV.BASE_API_URL}/users/self`, {
-          method: 'PATCH',
-          body: JSON.stringify({ discordId: this.discordId }),
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          credentials: 'include',
-        });
+        const response = await fetch(
+          `${ENV.BASE_API_URL}/external-accounts/link/${this.token}`,
+          {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+          }
+        );
 
         if (response.status === 204) {
           this.linkStatus = 'linked';


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 11 April 2024
<!--Developer Name Here-->
Developer Name: Joy Gupta

---

## Issue Ticket Number
- [Phase 2](https://github.com/Real-Dev-Squad/website-backend/issues/1974)


## Design Doc
- https://docs.google.com/document/d/1kEA80FHwheR2cPlbWzleHoMzgWB0J4WeMUNe7RlApL4/edit

### Dependent PR

- https://github.com/Real-Dev-Squad/website-backend/pull/
- https://github.com/Real-Dev-Squad/discord-slash-commands/pull/
## Description

In this PR I've just updated the API endpoint which is now responsible for linking external-account with user account. In short term for verification, we now have a dedicated API which stores all the essential information in user collection.

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->


### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

### Staging Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots

### Before
<img width="575" alt="Screenshot 2024-04-11 at 12 20 59 AM" src="https://github.com/Real-Dev-Squad/website-my/assets/56365512/641ac0bd-0c10-490f-9531-6c1cfe11392c">


### After
<img width="575" alt="Screenshot 2024-04-11 at 12 22 01 AM" src="https://github.com/Real-Dev-Squad/website-my/assets/56365512/4dd5ba36-9780-4be5-ac74-e851b8b92e5b">


https://github.com/Real-Dev-Squad/website-my/assets/56365512/56302c49-d618-456c-86bd-8895dd71c6b4


