### PR TITLE
Dev to Main Sync

### DIFF
--- a/app/styles/tasks.css
+++ b/app/styles/tasks.css
@@ -438,13 +438,19 @@
   padding: 18px;
   border-radius: 10px;
   background-color: var(--white);
+  overflow: auto;
   /* overflow-y: scroll; */
   position: absolute;
-  left: 30%;
-  right: 30%;
+  max-width: 60%;
+  max-height: 90%;
   gap: 20px;
   display: flex;
   flex-direction: column;
+}
+@media (max-width: 768px), (max-height: 100vh) and (orientation: portrait) {
+  .extension-form__container-main {
+    max-width: 95%;
+  }
 }
 .extension-form__container-main:hover {
   cursor: default;
@@ -465,6 +471,7 @@
 }
 
 .extension-form__content {
+  /* overflow: auto; */
   display: flex;
   justify-content: center;
   align-items: center;
@@ -705,13 +712,13 @@
 td {
   padding: 8px 2px;
   vertical-align: top;
-  min-width: 50%;
+  max-width: 20%;
 }
 .latest-table {
   width: 100%;
 }
 .latest-extension-info__content th {
-  text-align: right;
+  text-align: left;
 }
 .latest-extension-info__content td {
   text-align: left;


### PR DESCRIPTION
---------

<!-- Date Here in dd mmm yyyy-->
Date: `9th December, 2024`
<!--Developer Name Here-->
Developer Name: @DepayanMondal 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- #622 
## PRs going in this sync
<!--Issue ticket this PR closes-->
- #624 

## Description
The ER preview page previously hides the `Raise Extension` and `Close` buttons if the ER description to too long, preventing users from raising further ERs. Added scroll ability to the preview card to address this issue.
<!--Description of the changes made in this PR-->

### Documentation Updated?

- [x] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

https://github.com/user-attachments/assets/d2476daa-531a-451f-98ff-c9ec3e5b4596


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
![image](https://github.com/user-attachments/assets/0910a8ca-70dc-4404-81cd-bc95cb116164)
</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->
